### PR TITLE
feat(frontend): wire typing indicators, presence, and read receipts (#47)

### DIFF
--- a/frontend/src/components/chat/ChatItem.tsx
+++ b/frontend/src/components/chat/ChatItem.tsx
@@ -1,5 +1,7 @@
 import { BellOff } from 'lucide-react'
 import { cn } from '../../lib/utils'
+import { usePresenceStore } from '../../stores/presenceStore'
+import { useChatStore } from '../../stores/chatStore'
 import type { Chat } from '../../types'
 
 interface ChatItemProps {
@@ -50,6 +52,14 @@ function getChatDisplay(chat: Chat) {
 export default function ChatItem({ chat, isSelected, onClick }: ChatItemProps) {
   const { displayName, initials, isChannel, isGroup, color } = getChatDisplay(chat)
 
+  const members = (chat as any).members as { userId: string }[] | undefined
+  const otherUserId = chat.type === 'private' && members
+    ? members.find((m) => m.userId !== (chat as any).currentUserId)?.userId
+    : undefined
+  const isOnline = usePresenceStore((s) => otherUserId ? s.onlineUsers.has(otherUserId) : false)
+  const isDM = chat.type === 'private'
+
+  const typingUsers = useChatStore((s) => s.typingUsers[chat.id] ?? [])
   const lastMsgText = chat.lastMessage?.content ?? ''
   const lastMsgTime = chat.lastMessage?.createdAt ?? chat.createdAt
   const senderPrefix =
@@ -80,6 +90,9 @@ export default function ChatItem({ chat, isSelected, onClick }: ChatItemProps) {
             {initials}
           </div>
         )}
+        {isDM && isOnline && (
+          <div className="absolute right-0 bottom-0 h-3 w-3 rounded-full border-2 border-white bg-green-500" />
+        )}
       </div>
 
       <div className="min-w-0 flex-1">
@@ -93,7 +106,11 @@ export default function ChatItem({ chat, isSelected, onClick }: ChatItemProps) {
         </div>
         <div className="flex items-center justify-between">
           <p className="truncate text-xs text-holio-muted">
-            {senderPrefix}{lastMsgText}
+            {typingUsers.length > 0 ? (
+              <span className="text-holio-orange">typing...</span>
+            ) : (
+              <>{senderPrefix}{lastMsgText}</>
+            )}
           </p>
           <div className="ml-2 flex flex-shrink-0 items-center gap-1">
             {chat.muted && (

--- a/frontend/src/components/chat/ChatViewPanel.tsx
+++ b/frontend/src/components/chat/ChatViewPanel.tsx
@@ -4,8 +4,11 @@ import ChatHeader from './ChatHeader'
 import MessageBubble from './MessageBubble'
 import DateSeparator from './DateSeparator'
 import MessageInput from './MessageInput'
+import TypingIndicator from './TypingIndicator'
 import { useChatStore } from '../../stores/chatStore'
 import { useAuthStore } from '../../stores/authStore'
+import { usePresenceStore } from '../../stores/presenceStore'
+import { getSocket } from '../../services/socket.service'
 import type { Chat } from '../../types'
 
 function groupMessagesByDate(messages: { createdAt: string }[]) {
@@ -54,11 +57,25 @@ export default function ChatViewPanel() {
   const messagesLoading = useChatStore((s) => s.messagesLoading)
   const currentUserId = useAuthStore((s) => s.user?.id)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const lastReadRef = useRef<string | null>(null)
 
   useEffect(() => {
     const el = scrollRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [messages])
+
+  useEffect(() => {
+    if (!activeChat || !messages.length || !currentUserId) return
+    const lastMsg = messages[messages.length - 1]
+    if (lastMsg.senderId === currentUserId) return
+    if (lastReadRef.current === lastMsg.id) return
+
+    lastReadRef.current = lastMsg.id
+    const socket = getSocket()
+    if (socket) {
+      socket.emit('message:read', { chatId: activeChat.id, messageId: lastMsg.id })
+    }
+  }, [activeChat, messages, currentUserId])
 
   if (!activeChat) {
     return (
@@ -80,6 +97,19 @@ export default function ChatViewPanel() {
   const isGroupLike = activeChat.type === 'group' || activeChat.type === 'channel'
   const dateGroups = groupMessagesByDate(messages)
 
+  const chatMembers = (activeChat as any).members as { userId: string }[] | undefined
+  const otherUserId = activeChat.type === 'private' && chatMembers
+    ? chatMembers.find((m) => m.userId !== currentUserId)?.userId
+    : undefined
+  const peerOnline = usePresenceStore((s) => otherUserId ? s.onlineUsers.has(otherUserId) : false)
+  const peerLastSeen = usePresenceStore((s) => otherUserId ? s.lastSeen[otherUserId] : undefined)
+
+  const isDM = activeChat.type === 'private'
+  const isOnline = isDM ? peerOnline : false
+  const statusText = isDM
+    ? (peerOnline ? 'online' : (peerLastSeen ? `last seen ${new Date(peerLastSeen).toLocaleString([], { hour: '2-digit', minute: '2-digit' })}` : ''))
+    : (isGroupLike ? `${chatMembers?.length ?? 0} members` : '')
+
   return (
     <div className="flex flex-1 flex-col bg-holio-offwhite">
       <ChatHeader
@@ -87,8 +117,8 @@ export default function ChatViewPanel() {
         avatarUrl={activeChat.avatarUrl}
         initials={initials}
         avatarColor={color}
-        status="online"
-        isOnline
+        status={statusText}
+        isOnline={isOnline}
       />
 
       <div ref={scrollRef} className="flex flex-1 flex-col gap-2 overflow-y-auto px-6 py-4">
@@ -115,7 +145,7 @@ export default function ChatViewPanel() {
                     }),
                     isMine: msg.senderId === currentUserId,
                     senderName: msg.sender?.firstName,
-                    isRead: true,
+                    isRead: !!(msg as any).isRead || !!(msg as any).readAt,
                     isGroup: isGroupLike,
                     type: msg.type,
                     fileUrl: msg.fileUrl,
@@ -131,6 +161,7 @@ export default function ChatViewPanel() {
         ))}
       </div>
 
+      <TypingIndicator chatId={activeChat.id} />
       <MessageInput chatId={activeChat.id} />
     </div>
   )

--- a/frontend/src/components/chat/TypingIndicator.tsx
+++ b/frontend/src/components/chat/TypingIndicator.tsx
@@ -1,0 +1,27 @@
+import { useChatStore } from '../../stores/chatStore'
+
+interface TypingIndicatorProps {
+  chatId: string
+}
+
+export default function TypingIndicator({ chatId }: TypingIndicatorProps) {
+  const typingUsers = useChatStore((s) => s.typingUsers[chatId] ?? [])
+
+  if (typingUsers.length === 0) return null
+
+  const label =
+    typingUsers.length === 1
+      ? 'Someone is typing'
+      : `${typingUsers.length} people are typing`
+
+  return (
+    <div className="flex items-center gap-2 px-6 py-1.5">
+      <div className="flex items-center gap-0.5">
+        <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-holio-orange [animation-delay:0ms]" />
+        <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-holio-orange [animation-delay:150ms]" />
+        <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-holio-orange [animation-delay:300ms]" />
+      </div>
+      <span className="text-xs text-holio-muted">{label}</span>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 import { getSocket, connectSocket, disconnectSocket } from '../services/socket.service'
 import { useChatStore } from '../stores/chatStore'
 import { useAuthStore } from '../stores/authStore'
+import { usePresenceStore } from '../stores/presenceStore'
 import type { Message } from '../types'
 
 export function useSocket() {
@@ -11,6 +12,7 @@ export function useSocket() {
   const updateMessage = useChatStore((s) => s.updateMessage)
   const removeMessage = useChatStore((s) => s.removeMessage)
   const setTyping = useChatStore((s) => s.setTyping)
+  const updatePresence = usePresenceStore((s) => s.updatePresence)
 
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const joinedChatRef = useRef<string | null>(null)
@@ -35,14 +37,24 @@ export function useSocket() {
       setTyping(data.chatId, data.userId, data.isTyping)
     })
 
+    socket.on('presence:update', (data: { userId: string; isOnline: boolean; lastSeen?: string }) => {
+      updatePresence(data.userId, data.isOnline, data.lastSeen)
+    })
+
+    socket.on('message:read:update', (data: { messageId: string; readBy: string }) => {
+      updateMessage(data.messageId, { isRead: true } as Partial<Message>)
+    })
+
     return () => {
       socket.off('message:new')
       socket.off('message:edit')
       socket.off('message:delete')
       socket.off('typing:update')
+      socket.off('presence:update')
+      socket.off('message:read:update')
       disconnectSocket()
     }
-  }, [token, addMessage, updateMessage, removeMessage, setTyping])
+  }, [token, addMessage, updateMessage, removeMessage, setTyping, updatePresence])
 
   useEffect(() => {
     const socket = getSocket()
@@ -69,5 +81,11 @@ export function useSocket() {
     }, 2000)
   }, [])
 
-  return { emitTyping }
+  const emitRead = useCallback((chatId: string, messageId: string) => {
+    const socket = getSocket()
+    if (!socket) return
+    socket.emit('message:read', { chatId, messageId })
+  }, [])
+
+  return { emitTyping, emitRead }
 }

--- a/frontend/src/stores/presenceStore.ts
+++ b/frontend/src/stores/presenceStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand'
+
+interface PresenceState {
+  onlineUsers: Set<string>
+  lastSeen: Record<string, string>
+  setOnline: (userId: string) => void
+  setOffline: (userId: string, lastSeenAt?: string) => void
+  updatePresence: (userId: string, isOnline: boolean, lastSeenAt?: string) => void
+  isUserOnline: (userId: string) => boolean
+}
+
+export const usePresenceStore = create<PresenceState>((set, get) => ({
+  onlineUsers: new Set(),
+  lastSeen: {},
+
+  setOnline: (userId: string) =>
+    set((state) => {
+      const next = new Set(state.onlineUsers)
+      next.add(userId)
+      return { onlineUsers: next }
+    }),
+
+  setOffline: (userId: string, lastSeenAt?: string) =>
+    set((state) => {
+      const next = new Set(state.onlineUsers)
+      next.delete(userId)
+      const ls = lastSeenAt
+        ? { ...state.lastSeen, [userId]: lastSeenAt }
+        : state.lastSeen
+      return { onlineUsers: next, lastSeen: ls }
+    }),
+
+  updatePresence: (userId: string, isOnline: boolean, lastSeenAt?: string) => {
+    if (isOnline) {
+      get().setOnline(userId)
+    } else {
+      get().setOffline(userId, lastSeenAt)
+    }
+  },
+
+  isUserOnline: (userId: string) => get().onlineUsers.has(userId),
+}))


### PR DESCRIPTION
## Summary
- Wire real-time typing indicators, online presence, and read receipts into the frontend
- Add `presenceStore` (Zustand) tracking online users and last-seen timestamps
- Listen to `presence:update` and `message:read:update` socket events in `useSocket`
- Create `TypingIndicator` component with animated bouncing dots
- Replace hardcoded `isRead: true` in ChatViewPanel with real message read state
- Emit `message:read` events when the user views messages in the active chat
- Show online dot on DM chat avatars in the chat list
- Display "typing..." in chat list preview when someone is typing

## Test plan
- [ ] When a user types in a chat, the other user sees "typing..." in the chat list and animated dots above the input
- [ ] Online users show a green dot on their DM chat avatar
- [ ] ChatHeader shows "online" or "last seen" based on real presence data
- [ ] Read receipts (double check marks) reflect actual read state, not hardcoded true
- [ ] Typing indicators auto-clear after the user stops typing

Fixes #47
