### PR TITLE
feat(frontend): add BottomNavBar and FloatingActionButton for mobile (#58, #59)

### DIFF
--- a/frontend/src/components/layout/BottomNavBar.tsx
+++ b/frontend/src/components/layout/BottomNavBar.tsx
@@ -1,0 +1,110 @@
+import { MessageSquare, Users, Settings, Bot } from 'lucide-react'
+import { useUiStore, type NavItem } from '../../stores/uiStore'
+import { useChatStore } from '../../stores/chatStore'
+import { cn } from '../../lib/utils'
+
+type BottomTab = {
+  id: NavItem
+  label: string
+  icon: typeof MessageSquare
+  activeIcon: typeof MessageSquare
+}
+
+const TABS: BottomTab[] = [
+  { id: 'all', label: 'Chats', icon: MessageSquare, activeIcon: MessageSquare },
+  { id: 'contacts', label: 'Contacts', icon: Users, activeIcon: Users },
+  { id: 'bots', label: 'AI Agents', icon: Bot, activeIcon: Bot },
+]
+
+const SETTINGS_TAB = { id: 'settings' as const, label: 'Settings', icon: Settings }
+
+export default function BottomNavBar() {
+  const activeNavItem = useUiStore((s) => s.activeNavItem)
+  const setActiveNavItem = useUiStore((s) => s.setActiveNavItem)
+  const chats = useChatStore((s) => s.chats)
+
+  const totalUnread = chats.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0)
+
+  const handleTabPress = (id: NavItem | 'settings') => {
+    if (id === 'settings') {
+      window.location.href = '/settings'
+      return
+    }
+    setActiveNavItem(id)
+  }
+
+  const isActive = (id: string) => activeNavItem === id
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-40 flex border-t border-gray-200 bg-white md:hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      {TABS.map((tab) => {
+        const Icon = isActive(tab.id) ? tab.activeIcon : tab.icon
+        const active = isActive(tab.id)
+        const showBadge = tab.id === 'all' && totalUnread > 0
+
+        return (
+          <button
+            key={tab.id}
+            onClick={() => handleTabPress(tab.id)}
+            className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
+            style={{ minHeight: 44, minWidth: 44 }}
+          >
+            <div className="relative">
+              <div
+                className={cn(
+                  'flex items-center justify-center rounded-lg px-4 py-1 transition-colors',
+                  active && 'bg-holio-orange/15',
+                )}
+              >
+                <Icon
+                  className={cn(
+                    'h-6 w-6 transition-colors',
+                    active ? 'text-holio-orange' : 'text-gray-500',
+                  )}
+                  fill={active ? 'currentColor' : 'none'}
+                  strokeWidth={active ? 1.5 : 2}
+                />
+              </div>
+              {showBadge && (
+                <span className="absolute -top-1 right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-medium leading-none text-white">
+                  {totalUnread > 99 ? '99+' : totalUnread}
+                </span>
+              )}
+            </div>
+            <span
+              className={cn(
+                'text-xs font-medium tracking-wide',
+                active ? 'text-holio-orange' : 'text-gray-500',
+              )}
+            >
+              {tab.label}
+            </span>
+          </button>
+        )
+      })}
+
+      <button
+        onClick={() => handleTabPress('settings')}
+        className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
+        style={{ minHeight: 44, minWidth: 44 }}
+      >
+        <div
+          className={cn(
+            'flex items-center justify-center rounded-lg px-4 py-1',
+          )}
+        >
+          <SETTINGS_TAB.icon
+            className="h-6 w-6 text-gray-500 transition-colors"
+            strokeWidth={2}
+          />
+        </div>
+        <span className="text-xs font-medium tracking-wide text-gray-500">
+          {SETTINGS_TAB.label}
+        </span>
+      </button>
+    </nav>
+  )
+}

--- a/frontend/src/components/layout/FloatingActionButton.tsx
+++ b/frontend/src/components/layout/FloatingActionButton.tsx
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef } from 'react'
+import { Plus, Pencil, Users, Hash } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+interface FabAction {
+  id: string
+  icon: typeof Pencil
+  label: string
+  onClick: () => void
+}
+
+interface FloatingActionButtonProps {
+  onNewChat?: () => void
+  onNewGroup?: () => void
+  onNewChannel?: () => void
+}
+
+export default function FloatingActionButton({
+  onNewChat,
+  onNewGroup,
+  onNewChannel,
+}: FloatingActionButtonProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const actions: FabAction[] = [
+    { id: 'chat', icon: Pencil, label: 'New Chat', onClick: () => { onNewChat?.(); setOpen(false) } },
+    { id: 'group', icon: Users, label: 'New Group', onClick: () => { onNewGroup?.(); setOpen(false) } },
+    { id: 'channel', icon: Hash, label: 'New Channel', onClick: () => { onNewChannel?.(); setOpen(false) } },
+  ]
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handleEsc)
+    return () => document.removeEventListener('keydown', handleEsc)
+  }, [open])
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed bottom-20 right-4 z-50 flex flex-col items-end gap-3 md:bottom-6 md:right-6"
+    >
+      {/* Expanded action items */}
+      <div
+        className={cn(
+          'flex flex-col gap-2 transition-all duration-200',
+          open
+            ? 'pointer-events-auto translate-y-0 opacity-100'
+            : 'pointer-events-none translate-y-2 opacity-0',
+        )}
+      >
+        {actions.map((action, i) => (
+          <button
+            key={action.id}
+            onClick={action.onClick}
+            className="flex items-center gap-3 transition-all duration-200"
+            style={{
+              transitionDelay: open ? `${i * 50}ms` : '0ms',
+              opacity: open ? 1 : 0,
+              transform: open ? 'translateY(0) scale(1)' : 'translateY(8px) scale(0.9)',
+            }}
+          >
+            <span className="whitespace-nowrap rounded-lg bg-holio-dark px-3 py-1.5 text-xs font-medium text-white shadow-lg">
+              {action.label}
+            </span>
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-orange shadow-lg shadow-holio-orange/30">
+              <action.icon className="h-5 w-5 text-white" />
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Main FAB */}
+      <button
+        onClick={() => setOpen(!open)}
+        className={cn(
+          'flex h-[53px] w-[53px] items-center justify-center rounded-full bg-holio-orange shadow-lg shadow-holio-orange/30 transition-transform duration-200',
+          open && 'rotate-45',
+        )}
+        aria-label={open ? 'Close menu' : 'Create new'}
+      >
+        <Plus className="h-7 w-7 text-white" strokeWidth={2.5} />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,4 +1,6 @@
 import Sidebar from '../components/layout/Sidebar'
+import BottomNavBar from '../components/layout/BottomNavBar'
+import FloatingActionButton from '../components/layout/FloatingActionButton'
 import ChatListPanel from '../components/chat/ChatListPanel'
 import ChatViewPanel from '../components/chat/ChatViewPanel'
 import InfoPanel from '../components/chat/InfoPanel'
@@ -51,11 +53,12 @@ export default function ChatPage() {
 
   const isContactsView = activeNavItem === 'contacts'
 
-
   return (
     <div className={darkMode ? 'dark' : ''}>
       <div className="flex h-screen overflow-hidden bg-holio-offwhite">
-        <Sidebar />
+        <div className="hidden md:block">
+          <Sidebar />
+        </div>
         <ResizablePanel
           width={chatListWidth}
           minWidth={240}
@@ -85,6 +88,8 @@ export default function ChatPage() {
           </ResizablePanel>
         )}
       </div>
+      <FloatingActionButton />
+      <BottomNavBar />
       <GlobalSearch
         open={showGlobalSearch}
         onClose={() => setShowGlobalSearch(false)}


### PR DESCRIPTION
## Summary
- **BottomNavBar**: 4-tab mobile navigation (Chats, Contacts, AI Agents, Settings) with Holio Orange active state, unread badge on Chats, 44px touch targets, safe area padding, hidden on md+ breakpoint
- **FloatingActionButton**: 53x53px orange FAB with expand/collapse animation showing New Chat, New Group, New Channel actions with labels, click-outside/escape to close, positioned above bottom nav
- **ChatPage integration**: Sidebar hidden on mobile (shown md+), BottomNavBar and FAB rendered on mobile, both components in layout/ directory

## Test plan
- [ ] On mobile viewport (< 768px): bottom nav visible, sidebar hidden
- [ ] On desktop viewport (>= 768px): sidebar visible, bottom nav hidden
- [ ] Tap each bottom nav tab - active state shows orange icon/label
- [ ] Chats tab shows unread count badge
- [ ] FAB tap expands to show 3 action buttons with labels
- [ ] Tap outside or Escape closes FAB menu
- [ ] FAB rotates 45deg (plus becomes X) when open

Closes #58
Closes #59

Made with [Cursor](https://cursor.com)