### PR TITLE
feat(frontend): add secret chat, group chat, and channel views (#63, #64, #68, #69, #70, #71)

### DIFF
--- a/frontend/src/components/chat/ChannelSubscriberView.tsx
+++ b/frontend/src/components/chat/ChannelSubscriberView.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from 'react'
+import {
+  ArrowLeft,
+  Hash,
+  Phone,
+  MoreVertical,
+  Eye,
+  Share2,
+  BellOff,
+  LogOut,
+} from 'lucide-react'
+import DateSeparator from './DateSeparator'
+import { useChatStore } from '../../stores/chatStore'
+import { useAuthStore } from '../../stores/authStore'
+import { cn } from '../../lib/utils'
+
+interface ChannelSubscriberViewProps {
+  chatId: string
+}
+
+function groupMessagesByDate(messages: { createdAt: string }[]) {
+  const groups: { label: string; indices: number[] }[] = []
+  let lastLabel = ''
+
+  messages.forEach((msg, i) => {
+    const date = new Date(msg.createdAt)
+    const now = new Date()
+    const diffDays = Math.floor((now.getTime() - date.getTime()) / 86_400_000)
+
+    let label: string
+    if (diffDays === 0) label = 'Today'
+    else if (diffDays === 1) label = 'Yesterday'
+    else label = date.toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' })
+
+    if (label !== lastLabel) {
+      groups.push({ label, indices: [i] })
+      lastLabel = label
+    } else {
+      groups[groups.length - 1].indices.push(i)
+    }
+  })
+
+  return groups
+}
+
+export default function ChannelSubscriberView({ chatId }: ChannelSubscriberViewProps) {
+  const activeChat = useChatStore((s) => s.activeChat)
+  const messages = useChatStore((s) => s.messages)
+  const messagesLoading = useChatStore((s) => s.messagesLoading)
+  const currentUserId = useAuthStore((s) => s.user?.id)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages])
+
+  if (!activeChat) return null
+
+  const displayName = activeChat.name ?? 'Channel'
+  const memberCount = (activeChat as any).members?.length ?? 0
+  const dateGroups = groupMessagesByDate(messages)
+
+  return (
+    <div className="flex flex-1 flex-col bg-holio-offwhite">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4">
+        <div className="flex items-center gap-3">
+          <button className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100">
+            <Hash className="h-5 w-5 text-purple-600" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-holio-text">{displayName}</h3>
+            <p className="text-xs text-holio-muted">{memberCount} subscribers</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          {[Phone, MoreVertical].map((Icon, i) => (
+            <button
+              key={i}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+            >
+              <Icon className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div ref={scrollRef} className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4">
+        {messagesLoading && (
+          <div className="flex justify-center py-4">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
+          </div>
+        )}
+
+        {dateGroups.map((group) => (
+          <div key={group.label}>
+            <DateSeparator label={group.label} />
+            {group.indices.map((idx) => {
+              const msg = messages[idx]
+              const imageUrl = msg.type === 'image' ? (msg.fileUrl ?? msg.metadata?.files?.[0]?.url) : null
+
+              return (
+                <div
+                  key={msg.id}
+                  className="mb-3 overflow-hidden rounded-xl bg-white shadow-sm"
+                >
+                  {imageUrl && (
+                    <img
+                      src={imageUrl}
+                      alt=""
+                      className="h-48 w-full object-cover"
+                    />
+                  )}
+                  <div className="p-4">
+                    <div className="mb-2 flex items-center gap-2">
+                      <div className="flex h-6 w-6 items-center justify-center rounded-full bg-purple-100">
+                        <Hash className="h-3 w-3 text-purple-600" />
+                      </div>
+                      <span className="text-xs font-semibold text-holio-text">{displayName}</span>
+                      <span className="text-[11px] text-holio-muted">
+                        {new Date(msg.createdAt).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </span>
+                    </div>
+                    <p className="text-sm leading-relaxed text-holio-text">{msg.content}</p>
+                    <div className="mt-3 flex items-center justify-between border-t border-gray-50 pt-3">
+                      <div className="flex items-center gap-1 text-holio-muted">
+                        <Eye className="h-3.5 w-3.5" />
+                        <span className="text-xs">{(msg.metadata as any)?.viewCount ?? 0}</span>
+                      </div>
+                      <button className="flex items-center gap-1 rounded-lg px-2 py-1 text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+                        <Share2 className="h-3.5 w-3.5" />
+                        <span className="text-xs">Share</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex gap-3 border-t border-gray-100 bg-white p-3">
+        <button className="flex h-10 flex-1 items-center justify-center gap-2 rounded-xl bg-gray-100 text-sm font-medium text-holio-text transition-colors hover:bg-gray-200">
+          <BellOff className="h-4 w-4" />
+          Mute
+        </button>
+        <button className="flex h-10 flex-1 items-center justify-center gap-2 rounded-xl bg-red-50 text-sm font-medium text-red-500 transition-colors hover:bg-red-100">
+          <LogOut className="h-4 w-4" />
+          Leave
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/GroupChatView.tsx
+++ b/frontend/src/components/chat/GroupChatView.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect, useRef } from 'react'
+import { ArrowLeft, Phone, MoreVertical } from 'lucide-react'
+import MessageBubble from './MessageBubble'
+import DateSeparator from './DateSeparator'
+import MessageInput from './MessageInput'
+import TypingIndicator from './TypingIndicator'
+import InChatSearch from '../search/InChatSearch'
+import { useChatStore } from '../../stores/chatStore'
+import { useAuthStore } from '../../stores/authStore'
+import { useUiStore } from '../../stores/uiStore'
+import { getSocket } from '../../services/socket.service'
+import { cn } from '../../lib/utils'
+
+interface GroupChatViewProps {
+  chatId: string
+}
+
+const DEMO_TOPICS = ['General', 'Design', 'Development', 'Marketing', 'Random']
+
+function groupMessagesByDate(messages: { createdAt: string }[]) {
+  const groups: { label: string; indices: number[] }[] = []
+  let lastLabel = ''
+
+  messages.forEach((msg, i) => {
+    const date = new Date(msg.createdAt)
+    const now = new Date()
+    const diffDays = Math.floor((now.getTime() - date.getTime()) / 86_400_000)
+
+    let label: string
+    if (diffDays === 0) label = 'Today'
+    else if (diffDays === 1) label = 'Yesterday'
+    else label = date.toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' })
+
+    if (label !== lastLabel) {
+      groups.push({ label, indices: [i] })
+      lastLabel = label
+    } else {
+      groups[groups.length - 1].indices.push(i)
+    }
+  })
+
+  return groups
+}
+
+export default function GroupChatView({ chatId }: GroupChatViewProps) {
+  const activeChat = useChatStore((s) => s.activeChat)
+  const messages = useChatStore((s) => s.messages)
+  const messagesLoading = useChatStore((s) => s.messagesLoading)
+  const currentUserId = useAuthStore((s) => s.user?.id)
+  const showInChatSearch = useUiStore((s) => s.showInChatSearch)
+  const setShowInChatSearch = useUiStore((s) => s.setShowInChatSearch)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const lastReadRef = useRef<string | null>(null)
+
+  const [activeTopic, setActiveTopic] = useState<string | null>(null)
+
+  const hasTopics = activeChat?.type === 'group' && (activeChat as any).topics?.length > 0
+  const topics: string[] = hasTopics ? (activeChat as any).topics : DEMO_TOPICS
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages, activeTopic])
+
+  useEffect(() => {
+    if (!activeChat || !messages.length || !currentUserId) return
+    const lastMsg = messages[messages.length - 1]
+    if (lastMsg.senderId === currentUserId) return
+    if (lastReadRef.current === lastMsg.id) return
+
+    lastReadRef.current = lastMsg.id
+    const socket = getSocket()
+    if (socket) {
+      socket.emit('message:read', { chatId: activeChat.id, messageId: lastMsg.id })
+    }
+  }, [activeChat, messages, currentUserId])
+
+  if (!activeChat) return null
+
+  const displayName = activeChat.name ?? 'Group'
+  const initials = displayName
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+  const memberCount = (activeChat as any).members?.length ?? 0
+
+  const filteredMessages = activeTopic
+    ? messages.filter((msg) => (msg.metadata as any)?.topic === activeTopic)
+    : messages
+
+  const dateGroups = groupMessagesByDate(filteredMessages)
+
+  const isSameSenderAsPrev = (idx: number) => {
+    if (idx === 0) return false
+    return filteredMessages[idx].senderId === filteredMessages[idx - 1].senderId
+  }
+
+  return (
+    <div className="flex flex-1 flex-col bg-holio-offwhite">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4">
+        <div className="flex items-center gap-3">
+          <button className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div className="relative">
+            {activeChat.avatarUrl ? (
+              <img
+                src={activeChat.avatarUrl}
+                alt={displayName}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-600 text-sm font-semibold text-white">
+                {initials}
+              </div>
+            )}
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-holio-text">{displayName}</h3>
+            <p className="text-xs text-holio-muted">{memberCount} members</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          {[Phone, MoreVertical].map((Icon, i) => (
+            <button
+              key={i}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+            >
+              <Icon className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {hasTopics && (
+        <div className="flex gap-2 overflow-x-auto border-b border-gray-100 bg-white px-4 py-2 scrollbar-hide">
+          <button
+            onClick={() => setActiveTopic(null)}
+            className={cn(
+              'flex-shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+              activeTopic === null
+                ? 'bg-holio-orange text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+            )}
+          >
+            All
+          </button>
+          {topics.map((topic) => (
+            <button
+              key={topic}
+              onClick={() => setActiveTopic(topic)}
+              className={cn(
+                'flex-shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+                activeTopic === topic
+                  ? 'bg-holio-orange text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+              )}
+            >
+              {topic}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {showInChatSearch && (
+        <InChatSearch
+          chatId={activeChat.id}
+          open={showInChatSearch}
+          onClose={() => setShowInChatSearch(false)}
+        />
+      )}
+
+      <div ref={scrollRef} className="flex flex-1 flex-col gap-1 overflow-y-auto px-6 py-4">
+        {messagesLoading && (
+          <div className="flex justify-center py-4">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
+          </div>
+        )}
+
+        {dateGroups.map((group) => (
+          <div key={group.label}>
+            <DateSeparator label={group.label} />
+            {group.indices.map((idx) => {
+              const msg = filteredMessages[idx]
+              const isMine = msg.senderId === currentUserId
+              const sameSender = isSameSenderAsPrev(idx)
+              const senderInitial = msg.sender?.firstName?.[0]?.toUpperCase() ?? '?'
+
+              return (
+                <div key={msg.id} className={cn('flex gap-2', isMine ? 'justify-end' : 'justify-start')}>
+                  {!isMine && (
+                    <div className="w-6 flex-shrink-0">
+                      {!sameSender && (
+                        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-holio-lavender/30 text-[10px] font-semibold text-holio-text">
+                          {senderInitial}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  <div className="min-w-0 max-w-[70%]">
+                    <MessageBubble
+                      rawMessage={msg}
+                      message={{
+                        id: msg.id,
+                        content: msg.content,
+                        timestamp: new Date(msg.createdAt).toLocaleTimeString([], {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        }),
+                        isMine,
+                        senderName: !isMine && !sameSender ? msg.sender?.firstName : undefined,
+                        isRead: !!(msg as any).isRead || !!(msg as any).readAt,
+                        isGroup: true,
+                        type: msg.type,
+                        fileUrl: msg.fileUrl,
+                        metadata: msg.metadata,
+                        reactions: msg.reactions,
+                        scheduledAt: msg.scheduledAt,
+                        currentUserId,
+                      }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      <TypingIndicator chatId={activeChat.id} />
+      <MessageInput chatId={activeChat.id} />
+    </div>
+  )
+}

--- a/frontend/src/components/chat/SecretChatInvite.tsx
+++ b/frontend/src/components/chat/SecretChatInvite.tsx
@@ -1,0 +1,101 @@
+import { ArrowLeft, Lock, Phone, MoreVertical, Shield } from 'lucide-react'
+
+interface SecretChatInviteProps {
+  userName: string
+  userAvatar?: string
+  onAccept: () => void
+  onBack: () => void
+}
+
+const FEATURES = [
+  'Use end-to-end encryption',
+  'Leave no trace on servers',
+  'Have a self-destruct timer',
+  'Do not allow forwarding',
+]
+
+export default function SecretChatInvite({
+  userName,
+  userAvatar,
+  onAccept,
+  onBack,
+}: SecretChatInviteProps) {
+  const initials = userName
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  return (
+    <div className="flex flex-1 flex-col bg-holio-offwhite">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div className="relative">
+            {userAvatar ? (
+              <img
+                src={userAvatar}
+                alt={userName}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-sage text-sm font-semibold text-white">
+                {initials}
+              </div>
+            )}
+            <div className="absolute right-0 bottom-0 rounded-full bg-holio-sage p-0.5">
+              <Lock className="h-2.5 w-2.5 text-white" />
+            </div>
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-holio-text">{userName}</h3>
+            <p className="text-xs text-holio-muted">last seen recently</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          {[Phone, MoreVertical].map((Icon, i) => (
+            <button
+              key={i}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+            >
+              <Icon className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center px-4">
+        <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6 shadow-sm">
+          <p className="text-sm text-holio-text">
+            <span className="font-semibold">{userName}</span> invited you to join
+            a secret chat.
+          </p>
+          <p className="mt-4 text-sm font-bold text-holio-text">Secret chats:</p>
+          <ul className="mt-2 space-y-2.5">
+            {FEATURES.map((feature) => (
+              <li key={feature} className="flex items-start gap-2.5">
+                <Shield className="mt-0.5 h-4 w-4 flex-shrink-0 text-holio-sage" />
+                <span className="text-sm text-holio-text">{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="p-4">
+        <button
+          onClick={onAccept}
+          className="h-12 w-full rounded-xl bg-holio-orange font-semibold text-white transition-colors hover:bg-holio-orange/90"
+        >
+          Accept
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/SecretChatView.tsx
+++ b/frontend/src/components/chat/SecretChatView.tsx
@@ -1,0 +1,250 @@
+import { useState, useEffect, useRef } from 'react'
+import {
+  ArrowLeft,
+  Lock,
+  Phone,
+  MoreVertical,
+  Clock,
+  Search,
+  Check,
+  CheckCheck,
+} from 'lucide-react'
+import MessageBubble from './MessageBubble'
+import DateSeparator from './DateSeparator'
+import MessageInput from './MessageInput'
+import TypingIndicator from './TypingIndicator'
+import InChatSearch from '../search/InChatSearch'
+import { useChatStore } from '../../stores/chatStore'
+import { useAuthStore } from '../../stores/authStore'
+import { useUiStore } from '../../stores/uiStore'
+import { usePresenceStore } from '../../stores/presenceStore'
+import { getSocket } from '../../services/socket.service'
+import { cn } from '../../lib/utils'
+import type { Chat } from '../../types'
+
+const SELF_DESTRUCT_OPTIONS = [
+  { label: 'Off', value: 0 },
+  { label: '1s', value: 1 },
+  { label: '5s', value: 5 },
+  { label: '30s', value: 30 },
+  { label: '1m', value: 60 },
+  { label: '1h', value: 3600 },
+  { label: '1d', value: 86400 },
+  { label: '1w', value: 604800 },
+]
+
+function groupMessagesByDate(messages: { createdAt: string }[]) {
+  const groups: { label: string; indices: number[] }[] = []
+  let lastLabel = ''
+
+  messages.forEach((msg, i) => {
+    const date = new Date(msg.createdAt)
+    const now = new Date()
+    const diffDays = Math.floor((now.getTime() - date.getTime()) / 86_400_000)
+
+    let label: string
+    if (diffDays === 0) label = 'Today'
+    else if (diffDays === 1) label = 'Yesterday'
+    else label = date.toLocaleDateString([], { month: 'long', day: 'numeric', year: 'numeric' })
+
+    if (label !== lastLabel) {
+      groups.push({ label, indices: [i] })
+      lastLabel = label
+    } else {
+      groups[groups.length - 1].indices.push(i)
+    }
+  })
+
+  return groups
+}
+
+export default function SecretChatView() {
+  const activeChat = useChatStore((s) => s.activeChat)
+  const messages = useChatStore((s) => s.messages)
+  const messagesLoading = useChatStore((s) => s.messagesLoading)
+  const currentUserId = useAuthStore((s) => s.user?.id)
+  const showInChatSearch = useUiStore((s) => s.showInChatSearch)
+  const setShowInChatSearch = useUiStore((s) => s.setShowInChatSearch)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const lastReadRef = useRef<string | null>(null)
+
+  const [selfDestructTime, setSelfDestructTime] = useState(0)
+  const [showTimerMenu, setShowTimerMenu] = useState(false)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [messages])
+
+  useEffect(() => {
+    if (!activeChat || !messages.length || !currentUserId) return
+    const lastMsg = messages[messages.length - 1]
+    if (lastMsg.senderId === currentUserId) return
+    if (lastReadRef.current === lastMsg.id) return
+
+    lastReadRef.current = lastMsg.id
+    const socket = getSocket()
+    if (socket) {
+      socket.emit('message:read', { chatId: activeChat.id, messageId: lastMsg.id })
+    }
+  }, [activeChat, messages, currentUserId])
+
+  if (!activeChat) return null
+
+  const displayName = activeChat.name ?? 'Secret Chat'
+  const initials = displayName
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+  const dateGroups = groupMessagesByDate(messages)
+
+  const chatMembers = (activeChat as any).members as { userId: string }[] | undefined
+  const otherUserId = chatMembers?.find((m) => m.userId !== currentUserId)?.userId
+  const peerOnline = usePresenceStore((s) => otherUserId ? s.onlineUsers.has(otherUserId) : false)
+  const peerLastSeen = usePresenceStore((s) => otherUserId ? s.lastSeen[otherUserId] : undefined)
+
+  const statusText = peerOnline
+    ? 'online'
+    : peerLastSeen
+      ? `last seen ${new Date(peerLastSeen).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+      : ''
+
+  return (
+    <div className="flex flex-1 flex-col bg-holio-offwhite">
+      <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4">
+        <div className="flex items-center gap-3">
+          <button className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div className="relative">
+            {activeChat.avatarUrl ? (
+              <img
+                src={activeChat.avatarUrl}
+                alt={displayName}
+                className="h-10 w-10 rounded-full object-cover"
+              />
+            ) : (
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-sage text-sm font-semibold text-white">
+                {initials}
+              </div>
+            )}
+            <div className="absolute right-0 bottom-0 rounded-full bg-holio-sage p-0.5">
+              <Lock className="h-2.5 w-2.5 text-white" />
+            </div>
+          </div>
+          <div>
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-sm font-semibold text-holio-text">{displayName}</h3>
+              <Lock className="h-3.5 w-3.5 text-holio-sage" />
+            </div>
+            <p className="text-xs text-holio-muted">{statusText}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="relative">
+            <button
+              onClick={() => setShowTimerMenu(!showTimerMenu)}
+              className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:bg-gray-50',
+                selfDestructTime > 0 ? 'text-holio-orange' : 'text-holio-muted hover:text-holio-text',
+              )}
+            >
+              <Clock className="h-5 w-5" />
+            </button>
+            {showTimerMenu && (
+              <div className="absolute right-0 top-full z-50 mt-1 w-40 rounded-xl border border-gray-100 bg-white py-1 shadow-lg">
+                {SELF_DESTRUCT_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => {
+                      setSelfDestructTime(opt.value)
+                      setShowTimerMenu(false)
+                    }}
+                    className={cn(
+                      'flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors hover:bg-gray-50',
+                      selfDestructTime === opt.value
+                        ? 'font-medium text-holio-orange'
+                        : 'text-holio-text',
+                    )}
+                  >
+                    {opt.label}
+                    {selfDestructTime === opt.value && (
+                      <Check className="h-4 w-4 text-holio-orange" />
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          {[Phone, MoreVertical].map((Icon, i) => (
+            <button
+              key={i}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+            >
+              <Icon className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-1.5 bg-holio-sage/10 py-2">
+        <Lock className="h-3.5 w-3.5 text-holio-sage" />
+        <span className="text-xs text-holio-sage">Messages are end-to-end encrypted</span>
+      </div>
+
+      {showInChatSearch && (
+        <InChatSearch
+          chatId={activeChat.id}
+          open={showInChatSearch}
+          onClose={() => setShowInChatSearch(false)}
+        />
+      )}
+
+      <div ref={scrollRef} className="flex flex-1 flex-col gap-2 overflow-y-auto px-6 py-4">
+        {messagesLoading && (
+          <div className="flex justify-center py-4">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
+          </div>
+        )}
+
+        {dateGroups.map((group) => (
+          <div key={group.label}>
+            <DateSeparator label={group.label} />
+            {group.indices.map((idx) => {
+              const msg = messages[idx]
+              return (
+                <MessageBubble
+                  key={msg.id}
+                  rawMessage={msg}
+                  message={{
+                    id: msg.id,
+                    content: msg.content,
+                    timestamp: new Date(msg.createdAt).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    }),
+                    isMine: msg.senderId === currentUserId,
+                    senderName: msg.sender?.firstName,
+                    isRead: !!(msg as any).isRead || !!(msg as any).readAt,
+                    isGroup: false,
+                    type: msg.type,
+                    fileUrl: msg.fileUrl,
+                    metadata: msg.metadata,
+                    reactions: msg.reactions,
+                    scheduledAt: msg.scheduledAt,
+                    currentUserId,
+                  }}
+                />
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      <TypingIndicator chatId={activeChat.id} />
+      <MessageInput chatId={activeChat.id} />
+    </div>
+  )
+}

--- a/frontend/src/components/groups/ChannelAdminPanel.tsx
+++ b/frontend/src/components/groups/ChannelAdminPanel.tsx
@@ -12,10 +12,16 @@ import {
   Crown,
   ShieldCheck,
   Check,
+  Hash,
+  Pencil,
+  BarChart3,
+  Users,
+  Eye,
+  Forward,
 } from 'lucide-react'
 import api from '../../services/api.service'
 import { cn } from '../../lib/utils'
-import type { ChatMember, ChannelPermissions, Chat } from '../../types'
+import type { ChatMember, ChannelPermissions, Chat, Message } from '../../types'
 
 interface ChannelAdminPanelProps {
   chat: Chat
@@ -51,6 +57,7 @@ export default function ChannelAdminPanel({ chat, onClose }: ChannelAdminPanelPr
   const [saving, setSaving] = useState(false)
   const [inviteLinks, setInviteLinks] = useState<Array<{ token: string; expiresAt: string }>>([])
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
+  const [recentPosts, setRecentPosts] = useState<Message[]>([])
 
   const [name, setName] = useState(chat.name ?? '')
   const [description, setDescription] = useState(chat.description ?? '')
@@ -71,6 +78,20 @@ export default function ChannelAdminPanel({ chat, onClose }: ChannelAdminPanelPr
   useEffect(() => {
     fetchMembers()
   }, [fetchMembers])
+
+  useEffect(() => {
+    async function fetchRecentPosts() {
+      try {
+        const { data } = await api.get<Message[]>(`/chats/${chat.id}/messages`, {
+          params: { page: 1, limit: 3 },
+        })
+        setRecentPosts(data)
+      } catch {
+        // ignore
+      }
+    }
+    fetchRecentPosts()
+  }, [chat.id])
 
   const handleSaveSettings = async () => {
     setSaving(true)
@@ -162,6 +183,72 @@ export default function ChannelAdminPanel({ chat, onClose }: ChannelAdminPanelPr
       </div>
 
       <div className="flex-1 overflow-y-auto">
+        {/* Channel Identity */}
+        <div className="flex flex-col items-center border-b border-gray-100 px-4 py-5">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-purple-100">
+            <Hash className="h-8 w-8 text-purple-600" />
+          </div>
+          <h4 className="mt-2 text-sm font-semibold text-holio-text">{chat.name ?? 'Channel'}</h4>
+          <p className="text-xs text-holio-muted">channel, {members.length} subscribers</p>
+        </div>
+
+        {/* Admin Banner */}
+        <div className="mx-4 mt-4 flex items-center gap-2 rounded-lg bg-holio-orange/10 px-3 py-2.5">
+          <Shield className="h-4 w-4 flex-shrink-0 text-holio-orange" />
+          <span className="text-xs font-medium text-holio-orange">
+            You are the admin of this channel
+          </span>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex gap-2 px-4 py-4">
+          {(
+            [
+              [Pencil, 'Edit'],
+              [BarChart3, 'Statistics'],
+              [Users, 'Members'],
+              [Link, 'Invite Link'],
+            ] as const
+          ).map(([Icon, label]) => (
+            <button
+              key={label}
+              onClick={label === 'Invite Link' ? handleGenerateLink : undefined}
+              className="flex flex-1 flex-col items-center gap-1.5 rounded-xl bg-gray-50 py-3 text-holio-muted transition-colors hover:bg-holio-lavender/20 hover:text-holio-text"
+            >
+              <Icon className="h-4 w-4" />
+              <span className="text-[10px] font-medium">{label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Recent Posts */}
+        {recentPosts.length > 0 && (
+          <div className="border-b border-gray-100 px-4 pb-4">
+            <h4 className="mb-3 text-xs font-semibold tracking-wide text-holio-muted uppercase">
+              Recent Posts
+            </h4>
+            <div className="space-y-2">
+              {recentPosts.map((post) => (
+                <div key={post.id} className="rounded-lg bg-gray-50 p-3">
+                  <p className="line-clamp-2 text-xs text-holio-text">{post.content}</p>
+                  <div className="mt-2 flex items-center gap-3 text-[10px] text-holio-muted">
+                    <span className="flex items-center gap-1">
+                      <Eye className="h-3 w-3" />
+                      {(post.metadata as any)?.viewCount ?? 0}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Forward className="h-3 w-3" />
+                      {(post.metadata as any)?.forwardCount ?? 0}
+                    </span>
+                    <span className="ml-auto">
+                      {new Date(post.createdAt).toLocaleDateString([], { month: 'short', day: 'numeric' })}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
         {/* Channel Settings */}
         <div className="border-b border-gray-100 px-4 py-4">
           <h4 className="mb-3 text-xs font-semibold tracking-wide text-holio-muted uppercase">


### PR DESCRIPTION
## Summary
- **SecretChatInvite**: invitation screen with encryption info card, feature bullet list with Shield icons, and full-width Accept button
- **SecretChatView**: encrypted chat with Lock icon indicators in header and avatar, end-to-end encryption banner, self-destruct timer selector menu
- **GroupChatView**: group messages with sender name (orange) above bubbles, 24px sender avatars, consecutive message grouping, horizontal scrollable topics bar with pill filters
- **ChannelAdminPanel**: updated with channel identity header (Hash icon), admin banner, quick action buttons (Edit, Statistics, Members, Invite Link), recent posts section with view/forward metrics
- **ChannelSubscriberView**: post-style full-width card layout for channel content with view counts, share buttons, and Mute/Leave footer actions

## Test plan
- [ ] Verify SecretChatInvite renders with user name, avatar overlay with Lock, and Accept callback fires
- [ ] Verify SecretChatView shows encryption banner, Lock icon in header, and self-destruct timer menu opens/selects correctly
- [ ] Verify GroupChatView shows sender names in orange, avatars for received messages, and consecutive messages are grouped (no repeated avatar/name)
- [ ] Verify GroupChatView topics bar filters messages when a topic pill is selected
- [ ] Verify ChannelAdminPanel shows admin banner, action buttons row, and recent posts with engagement metrics
- [ ] Verify ChannelSubscriberView renders messages as post cards with view count and share button
- [ ] Verify ChannelSubscriberView shows Mute/Leave footer buttons instead of message input

Closes #63
Closes #64
Closes #68
Closes #69
Closes #70
Closes #71
