### PR TITLE
feat(chat): add scroll collapse behavior to ChatListPanel (#104)

### DIFF
--- a/frontend/src/components/chat/ChatListPanel.tsx
+++ b/frontend/src/components/chat/ChatListPanel.tsx
@@ -41,7 +41,15 @@ export default function ChatListPanel({ selectedChatId, onSelectChat }: ChatList
   const currentUser = useAuthStore((s) => s.user)
   useEffect(() => { fetchChats(activeCompany?.id) }, [fetchChats, activeCompany?.id])
   useEffect(() => { fetchStories() }, [fetchStories])
-  const handleScroll = useCallback(() => { const el = scrollContainerRef.current; if (el) setScrolled(el.scrollTop > 60) }, [])
+  const rafRef = useRef<number>(0)
+  const handleScroll = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    rafRef.current = requestAnimationFrame(() => {
+      const el = scrollContainerRef.current
+      if (el) setScrolled(el.scrollTop > 80)
+    })
+  }, [])
+  useEffect(() => { return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current) } }, [])
   const tabCounts = useMemo(() => { const f = filterChats(chats); return { all: f.length, groups: f.filter((c) => c.type === 'group').length, channels: f.filter((c) => c.type === 'channel').length, bots: f.filter((c) => c.type === 'bot').length } }, [chats, filterChats])
   const displayedChats = useMemo(() => {
     let result = filterChats(chats)
@@ -52,22 +60,22 @@ export default function ChatListPanel({ selectedChatId, onSelectChat }: ChatList
 
   return (
     <div className="flex h-full w-full flex-col bg-white sm:w-80 sm:flex-shrink-0 sm:border-r sm:border-gray-100">
-      <div className={cn('flex flex-shrink-0 items-center justify-between px-4 transition-all duration-200', scrolled ? 'h-12' : 'h-14')}>
-        <h1 className={cn('font-bold leading-tight text-holio-text transition-all duration-200', scrolled ? 'text-lg' : 'text-xl')}>Chats</h1>
+      <div className={cn('flex flex-shrink-0 items-center justify-between px-4 transition-all duration-300 ease-in-out will-change-[height]', scrolled ? 'h-11' : 'h-14')}>
+        <h1 className={cn('font-bold leading-tight text-holio-text transition-all duration-300 ease-in-out', scrolled ? 'text-lg' : 'text-xl')}>Chats</h1>
         <button onClick={() => setShowSearch((v) => !v)} className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-100 hover:text-holio-text" title="Search"><Search className="h-5 w-5" /></button>
       </div>
       {showSearch && (<div className="px-4 pb-2"><div className="relative"><Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-holio-muted" /><input type="text" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} placeholder="Search..." className="w-full rounded-xl bg-gray-50 py-2 pr-4 pl-9 text-sm text-holio-text outline-none placeholder:text-holio-muted focus:ring-2 focus:ring-holio-lavender/50" autoFocus /></div></div>)}
-      <div className={cn('overflow-hidden transition-all duration-300', scrolled ? 'max-h-0 opacity-0' : 'max-h-24 opacity-100')}>
+      <div className={cn('overflow-hidden transition-all duration-300 ease-in-out will-change-[max-height,opacity]', scrolled ? 'max-h-0 opacity-0' : 'max-h-24 opacity-100')}>
         {storyGroups.length > 0 && (<div className="flex gap-3 overflow-x-auto px-4 py-2 scrollbar-none">{storyGroups.map((group, index) => (<StoryCircle key={group.user.id} group={group} isOwn={group.user.id === currentUser?.id} onClick={() => openViewer(index)} />))}</div>)}
       </div>
-      <div className={cn('z-10 bg-white transition-all duration-200', scrolled ? 'sticky top-0 shadow-sm' : '')}>
+      <div className={cn('sticky top-0 z-10 bg-white transition-shadow duration-300 ease-in-out', scrolled ? 'shadow-sm' : 'shadow-none')}>
         <div className="flex items-center gap-1 overflow-x-auto px-4 scrollbar-none">
           {FILTER_TABS.map((tab) => { const isActive = activeTab === tab.key; const count = tabCounts[tab.key as keyof typeof tabCounts]; return (<button key={tab.key} onClick={() => setActiveTab(tab.key)} className={cn('flex flex-shrink-0 items-center gap-1.5 border-b-2 px-3 pb-2 pt-1.5 text-[14px] font-medium transition-colors', isActive ? 'border-holio-orange text-holio-orange' : 'border-transparent text-holio-muted hover:text-holio-text')}>{tab.label}{count !== undefined && count > 0 && (<span className={cn('rounded-full px-1.5 py-0.5 text-[11px] font-medium leading-none', isActive ? 'bg-holio-orange/15 text-holio-orange' : 'bg-gray-200/60 text-holio-muted')}>{count}</span>)}</button>) })}
         </div>
         <div className="h-px bg-gray-100" />
       </div>
       <FolderTabs />
-      <div ref={scrollContainerRef} onScroll={handleScroll} className="relative flex-1 overflow-y-auto">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="relative flex-1 overflow-y-auto scrollbar-none">
         {loading ? (<><ChatSkeleton /><ChatSkeleton /><ChatSkeleton /><ChatSkeleton /><ChatSkeleton /></>) : displayedChats.length === 0 ? (<div className="flex flex-col items-center justify-center px-6 py-16 text-center"><div className="flex h-16 w-16 items-center justify-center rounded-full bg-holio-lavender/20"><MessageSquarePlus className="h-8 w-8 text-holio-lavender" /></div><p className="mt-4 text-sm font-medium text-holio-text">No conversations yet</p><p className="mt-1 text-xs text-holio-muted">Start a new chat to begin messaging</p></div>) : displayedChats.map((chat) => (<ChatItem key={chat.id} chat={chat} isSelected={selectedChatId === chat.id} onClick={() => onSelectChat(chat)} />))}
         <button className="absolute right-4 bottom-4 flex h-14 w-14 items-center justify-center rounded-full bg-holio-orange shadow-lg transition-transform hover:scale-105 active:scale-95" title="New chat"><Plus className="h-6 w-6 text-white" /></button>
       </div>


### PR DESCRIPTION
## Summary
- Scroll-aware header collapse: title shrinks from text-xl to text-lg, header height reduces from h-14 to h-11
- Stories row smoothly hides with max-h/opacity transition and will-change hints
- Filter tabs are always sticky with smooth shadow transition on scroll
- requestAnimationFrame-based scroll handler prevents jitter during fast scrolling
- Scroll container gets scrollbar-none for cleaner UX
- Search icon remains accessible in both expanded and collapsed states

## Test plan
- [ ] Scroll down in chat list, verify header smoothly collapses
- [ ] Scroll back to top, verify header smoothly expands
- [ ] Fast scroll up/down repeatedly, verify no jitter or layout shift
- [ ] Verify stories row hides/shows with smooth animation
- [ ] Verify filter tabs remain sticky and get shadow when scrolled
- [ ] Verify search icon is accessible in both states

Closes #104

Made with [Cursor](https://cursor.com)