### PR TITLE
feat(chat): redesign Private Chat View to match Figma specs (#105)

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -1,4 +1,6 @@
-import { ChevronLeft, Phone, MoreVertical } from 'lucide-react'
+import { ArrowLeft, Phone, MoreVertical, Search } from 'lucide-react'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useUiStore } from '../../stores/uiStore'
 
 interface ChatHeaderProps {
@@ -9,6 +11,8 @@ interface ChatHeaderProps {
   status: string
   isOnline: boolean
   onBack?: () => void
+  userId?: string
+  chatId?: string
 }
 
 export default function ChatHeader({
@@ -20,17 +24,20 @@ export default function ChatHeader({
   isOnline,
   onBack,
 }: ChatHeaderProps) {
+  const navigate = useNavigate()
   const toggleInfoPanel = useUiStore((s) => s.toggleInfoPanel)
+  const setShowInChatSearch = useUiStore((s) => s.setShowInChatSearch)
+  const [showMenu, setShowMenu] = useState(false)
 
   return (
-    <div className="flex h-[72px] flex-shrink-0 items-center justify-between border-b border-gray-200 bg-[#fafafa] px-3">
+    <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-3">
       <div className="flex items-center gap-2">
         {onBack && (
           <button
             onClick={onBack}
             className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-100 hover:text-holio-text md:hidden"
           >
-            <ChevronLeft className="h-6 w-6" />
+            <ArrowLeft className="h-5 w-5" />
           </button>
         )}
 
@@ -54,12 +61,12 @@ export default function ChatHeader({
               </div>
             )}
             {isOnline && (
-              <div className="absolute right-0 bottom-0 h-3 w-3 rounded-full border-2 border-[#fafafa] bg-green-500" />
+              <div className="absolute right-0 bottom-0 h-3 w-3 rounded-full border-2 border-white bg-green-500" />
             )}
           </div>
           <div>
-            <h3 className="text-lg font-medium leading-tight text-holio-text">{name}</h3>
-            <p className="text-sm text-holio-muted">{status}</p>
+            <h3 className="text-base font-semibold leading-tight text-holio-text">{name}</h3>
+            <p className="text-xs text-[#8E8E93]">{status}</p>
           </div>
         </button>
       </div>

--- a/frontend/src/components/chat/ChatViewPanel.tsx
+++ b/frontend/src/components/chat/ChatViewPanel.tsx
@@ -57,7 +57,7 @@ export default function ChatViewPanel() {
   }, [activeChat, messages, currentUserId])
 
   if (!activeChat) {
-    return (<div className="flex flex-1 flex-col items-center justify-center bg-holio-offwhite">
+    return (<div className="flex flex-1 flex-col items-center justify-center bg-white">
       <div className="flex h-20 w-20 items-center justify-center rounded-full bg-holio-lavender/30"><MessageSquare className="h-10 w-10 text-holio-lavender" /></div>
       <h3 className="mt-4 text-lg font-semibold text-holio-text">Select a chat to start messaging</h3>
       <p className="mt-1 text-sm text-holio-muted">Choose a conversation from the list</p>
@@ -78,10 +78,10 @@ export default function ChatViewPanel() {
     : (isGroupLike ? `${chatMembers?.length ?? 0} members` : '')
 
   return (
-    <div className="flex flex-1 flex-col bg-holio-offwhite">
-      <ChatHeader name={displayName} avatarUrl={activeChat.avatarUrl} initials={initials} avatarColor={color} status={statusText} isOnline={isOnline} />
+    <div className="flex flex-1 flex-col bg-white">
+      <ChatHeader name={displayName} avatarUrl={activeChat.avatarUrl} initials={initials} avatarColor={color} status={statusText} isOnline={isOnline} userId={otherUserId} chatId={activeChat.id} />
       {showInChatSearch && <InChatSearch chatId={activeChat.id} open={showInChatSearch} onClose={() => setShowInChatSearch(false)} />}
-      <div ref={scrollRef} className="flex flex-1 flex-col gap-1 overflow-y-auto bg-gradient-to-b from-holio-lavender/20 to-holio-lavender/10 px-4 py-4">
+      <div ref={scrollRef} className="flex flex-1 flex-col gap-0.5 overflow-y-auto bg-[#F5F3FF] px-4 py-4">
         {messagesLoading && (<div className="flex justify-center py-4"><div className="h-6 w-6 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" /></div>)}
         {dateGroups.map((group) => (<div key={group.label}><DateSeparator label={group.label} />
           {group.indices.map((idx) => { const msg = messages[idx]; return (<MessageBubble key={msg.id} rawMessage={msg} message={{ id: msg.id, content: msg.content, timestamp: new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }), isMine: msg.senderId === currentUserId, senderName: msg.sender?.firstName, isRead: !!(msg as any).isRead || !!(msg as any).readAt, isEdited: !!(msg as any).isEdited, isGroup: isGroupLike, type: msg.type, fileUrl: msg.fileUrl, metadata: msg.metadata, reactions: msg.reactions, scheduledAt: msg.scheduledAt, currentUserId }} />) })}

--- a/frontend/src/components/chat/DateSeparator.tsx
+++ b/frontend/src/components/chat/DateSeparator.tsx
@@ -4,8 +4,8 @@ interface DateSeparatorProps {
 
 export default function DateSeparator({ label }: DateSeparatorProps) {
   return (
-    <div className="flex items-center justify-center py-4">
-      <span className="rounded-full bg-[rgba(114,131,145,0.4)] px-3 py-1 text-[13px] font-medium text-white shadow-sm">
+    <div className="flex items-center justify-center py-3">
+      <span className="rounded-full bg-white/80 px-4 py-1 text-xs font-medium text-[#8E8E93] shadow-sm backdrop-blur-sm">
         {label}
       </span>
     </div>

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -22,6 +22,7 @@ export interface MessageData {
   senderType?: 'user' | 'bot' | 'system'; isRead: boolean; isGroup: boolean; readCount?: number
   type: Message['type']; fileUrl?: string | null; metadata?: MessageMetadata | null
   reactions?: MessageReaction[]; scheduledAt?: string | null; currentUserId?: string
+  isEdited?: boolean
 }
 
 interface MessageBubbleProps { message: MessageData; rawMessage?: Message }
@@ -36,7 +37,7 @@ function GroupReadPopup({ messageId, onClose }: { messageId: string; onClose: ()
   useState(() => { fetch() })
   return (
     <div className="absolute right-0 bottom-6 z-50 w-48 rounded-lg border border-gray-100 bg-white p-2 shadow-lg">
-      <div className="mb-1 flex items-center justify-between">
+      <div className="mb-2 flex items-center justify-between">
         <span className="text-[11px] font-semibold text-holio-text">Read by</span>
         <button onClick={onClose} className="rounded-full p-0.5 text-holio-muted hover:text-holio-text"><X className="h-3 w-3" /></button>
       </div>
@@ -53,8 +54,8 @@ function GroupReadPopup({ messageId, onClose }: { messageId: string; onClose: ()
 
 function BubbleTail({ isMine }: { isMine: boolean }) {
   return (
-    <svg className={cn('absolute bottom-0 h-3 w-3', isMine ? '-right-1.5' : '-left-1.5')} viewBox="0 0 12 12">
-      <path d={isMine ? 'M0 0 L0 12 L12 12 Q4 12 0 0Z' : 'M12 0 L12 12 L0 12 Q8 12 12 0Z'} fill={isMine ? '#C6D5BA' : '#ffffff'} />
+    <svg className={cn('absolute bottom-0 h-[14px] w-[10px]', isMine ? '-right-[9px]' : '-left-[9px]')} viewBox="0 0 10 14" preserveAspectRatio="none">
+      <path {isMine ? "M0 0 C0 7 4 12 10 14 L0 14Z" : "M10 0 C10 7 6 12 0 14 L10 14Z"} fill={isMine ? '#C6D5BA' : '#ffffff'} />
     </svg>
   )
 }
@@ -132,7 +133,7 @@ export default function MessageBubble({ message, rawMessage }: MessageBubbleProp
     }
   }
 
-  const readReceiptIcon = message.isMine && (message.isRead ? <CheckCheck className="h-3.5 w-3.5 text-holio-orange" /> : <Check className="h-3.5 w-3.5 text-holio-muted" />)
+  const readReceiptIcon = message.isMine && (message.isRead ? <CheckCheck className="h-3.5 w-3.5 text-[#FF9220]" /> : <Check className="h-3.5 w-3.5 text-[#8E8E93]" />)
 
   if (message.type === 'videoNote') {
     return (<>
@@ -149,18 +150,18 @@ export default function MessageBubble({ message, rawMessage }: MessageBubbleProp
   }
 
   return (<>
-    <div className={cn('group relative mb-1 flex', message.isMine ? 'justify-end' : 'justify-start')} onContextMenu={handleContextMenu} onMouseEnter={() => setShowReactionPicker(true)} onMouseLeave={() => setShowReactionPicker(false)}>
-      <div className="relative max-w-[70%]">
+    <div className={cn('group relative mb-2 flex', message.isMine ? 'justify-end' : 'justify-start')} onContextMenu={handleContextMenu} onMouseEnter={() => setShowReactionPicker(true)} onMouseLeave={() => setShowReactionPicker(false)}>
+      <div className="relative max-w-[80%]">
         {showReactionPicker && <ReactionPicker onReact={handleReact} isMine={message.isMine} />}
-        {isScheduled && (<div className="mb-1 flex items-center gap-1 text-[11px] text-holio-muted"><Clock className="h-3 w-3" /><span>Scheduled for {new Date(message.scheduledAt!).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span></div>)}
+        {isScheduled && (<div className="mb-2 flex items-center gap-1 text-[11px] text-holio-muted"><Clock className="h-3 w-3" /><span>Scheduled for {new Date(message.scheduledAt!).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span></div>)}
         <div className={cn('relative', isMedia ? 'overflow-hidden rounded-2xl' : 'px-3.5 py-2',
-          message.isMine ? (isMedia ? 'rounded-2xl rounded-br-sm' : 'rounded-2xl rounded-br-sm bg-holio-sage text-holio-text') : (isMedia ? 'rounded-2xl rounded-bl-sm' : 'rounded-2xl rounded-bl-sm bg-white text-holio-text'))}>
+          message.isMine ? (isMedia ? 'rounded-2xl rounded-br-sm' : 'rounded-2xl rounded-br-sm bg-[#C6D5BA] text-holio-text') : (isMedia ? 'rounded-2xl rounded-bl-sm' : 'rounded-2xl rounded-bl-sm bg-white text-holio-text'))}>
           {!isMedia && <BubbleTail isMine={message.isMine} />}
           {isMedia ? (
-            <div className={cn('rounded-2xl p-1', message.isMine ? 'rounded-br-sm bg-holio-sage' : 'rounded-bl-sm bg-white')}>
+            <div className={cn('rounded-2xl p-1', message.isMine ? 'rounded-br-sm bg-[#C6D5BA]' : 'rounded-bl-sm bg-white')}>
               {!message.isMine && message.isGroup && message.senderName && <p className="mb-1 px-2 pt-1 text-xs font-medium text-holio-orange">{message.senderName}</p>}
               {renderContent()}
-              <div className="mt-1 flex items-center justify-end gap-1 px-2 pb-1 text-holio-muted"><span className="text-[11px]">{message.timestamp}</span>{readReceiptIcon}</div>
+              <div className="mt-1 flex items-center justify-end gap-1 px-2 pb-1 text-[#8E8E93]">{message.isEdited && <span className="text-[10px] italic">edited</span>}<span className="text-[11px]">{message.timestamp}</span>{readReceiptIcon}</div>
             </div>
           ) : (<>
             {!message.isMine && message.isGroup && message.senderName && <p className="mb-0.5 text-xs font-medium text-holio-orange">{message.senderName}</p>}

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -416,9 +416,9 @@ export default function MessageInput({ chatId }: MessageInputProps) {
           value={text}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          placeholder="Write a message... (type @ to mention a bot)"
+          placeholder="Message"
           rows={1}
-          className="w-full resize-none rounded-xl bg-gray-50 px-4 py-2.5 text-sm text-holio-text outline-none placeholder:text-holio-muted focus:ring-2 focus:ring-holio-lavender/50 dark:bg-[#1A2A2D] dark:text-white"
+          className="w-full resize-none rounded-2xl bg-gray-50 px-4 py-2.5 text-sm text-holio-text outline-none placeholder:text-[#8E8E93] focus:ring-2 focus:ring-holio-lavender/50 dark:bg-[#1A2A2D] dark:text-white"
           style={{ maxHeight: 120 }}
         />
       </div>

--- a/frontend/src/components/layout/BottomNavBar.tsx
+++ b/frontend/src/components/layout/BottomNavBar.tsx
@@ -1,83 +1,82 @@
-import { MessageSquare, Users, Settings, Bot } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { MessageCircle, Users, Settings, Bot } from 'lucide-react'
 import { useUiStore, type NavItem } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { cn } from '../../lib/utils'
 
 type BottomTab = {
-  id: NavItem
+  id: NavItem | 'settings'
   label: string
-  icon: typeof MessageSquare
-  activeIcon: typeof MessageSquare
+  icon: typeof MessageCircle
+  route?: string
 }
 
 const TABS: BottomTab[] = [
-  { id: 'all', label: 'Chats', icon: MessageSquare, activeIcon: MessageSquare },
-  { id: 'contacts', label: 'Contacts', icon: Users, activeIcon: Users },
-  { id: 'bots', label: 'AI Agents', icon: Bot, activeIcon: Bot },
+  { id: 'all', label: 'Chats', icon: MessageCircle },
+  { id: 'contacts', label: 'Contacts', icon: Users, route: '/contacts' },
+  { id: 'settings', label: 'Settings', icon: Settings, route: '/settings' },
+  { id: 'bots', label: 'AI Agents', icon: Bot, route: '/bots' },
 ]
 
-const SETTINGS_TAB = { id: 'settings' as const, label: 'Settings', icon: Settings }
-
 export default function BottomNavBar() {
+  const navigate = useNavigate()
+  const location = useLocation()
   const activeNavItem = useUiStore((s) => s.activeNavItem)
   const setActiveNavItem = useUiStore((s) => s.setActiveNavItem)
   const chats = useChatStore((s) => s.chats)
 
   const totalUnread = chats.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0)
 
-  const handleTabPress = (id: NavItem | 'settings') => {
-    if (id === 'settings') {
-      window.location.href = '/settings'
-      return
-    }
-    setActiveNavItem(id)
+  const isActive = (tab: BottomTab) => {
+    if (tab.route) return location.pathname.startsWith(tab.route)
+    return activeNavItem === tab.id && location.pathname === '/'
   }
 
-  const isActive = (id: string) => activeNavItem === id
+  const handleTabPress = (tab: BottomTab) => {
+    if (tab.route) {
+      navigate(tab.route)
+    } else {
+      setActiveNavItem(tab.id as NavItem)
+      navigate('/')
+    }
+  }
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 flex border-t border-gray-200 bg-white md:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-4 border-t border-gray-200 bg-white md:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
       {TABS.map((tab) => {
-        const Icon = isActive(tab.id) ? tab.activeIcon : tab.icon
-        const active = isActive(tab.id)
+        const active = isActive(tab)
+        const Icon = tab.icon
         const showBadge = tab.id === 'all' && totalUnread > 0
 
         return (
           <button
             key={tab.id}
-            onClick={() => handleTabPress(tab.id)}
-            className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-            style={{ minHeight: 44, minWidth: 44 }}
+            onClick={() => handleTabPress(tab)}
+            className="relative flex flex-col items-center justify-center gap-0.5 py-2"
+            style={{ minHeight: 44 }}
           >
-            <div className="relative">
-              <div
+            <div className="relative flex items-center justify-center">
+              <Icon
                 className={cn(
-                  'flex items-center justify-center rounded-lg px-4 py-1 transition-colors',
-                  active && 'bg-holio-orange/15',
+                  'h-6 w-6 transition-colors',
+                  active ? 'text-holio-orange' : 'text-[#8E8E93]',
                 )}
-              >
-                <Icon
-                  className={cn(
-                    'h-6 w-6 transition-colors',
-                    active ? 'text-holio-orange' : 'text-gray-500',
-                  )}
-                  fill={active ? 'currentColor' : 'none'}
-                  strokeWidth={active ? 1.5 : 2}
-                />
-              </div>
+                fill={active ? 'currentColor' : 'none'}
+                strokeWidth={active ? 1.5 : 2}
+              />
               {showBadge && (
-                <span className="absolute -top-1 right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-medium leading-none text-white">
+                <span className="absolute -right-2.5 -top-1.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-semibold leading-none text-white">
                   {totalUnread > 99 ? '99+' : totalUnread}
                 </span>
               )}
             </div>
             <span
               className={cn(
-                'text-xs font-medium tracking-wide',
-                active ? 'text-holio-orange' : 'text-gray-500',
+                'text-[11px] font-medium',
+                active ? 'text-holio-orange' : 'text-[#8E8E93]',
               )}
             >
               {tab.label}
@@ -85,26 +84,6 @@ export default function BottomNavBar() {
           </button>
         )
       })}
-
-      <button
-        onClick={() => handleTabPress('settings')}
-        className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-        style={{ minHeight: 44, minWidth: 44 }}
-      >
-        <div
-          className={cn(
-            'flex items-center justify-center rounded-lg px-4 py-1',
-          )}
-        >
-          <SETTINGS_TAB.icon
-            className="h-6 w-6 text-gray-500 transition-colors"
-            strokeWidth={2}
-          />
-        </div>
-        <span className="text-xs font-medium tracking-wide text-gray-500">
-          {SETTINGS_TAB.label}
-        </span>
-      </button>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary

- **ChatHeader**: Replaced ChevronLeft with ArrowLeft back button, 48px avatar circle, name (bold) + status (muted xs text in #8E8E93), Phone icon, kebab MoreVertical menu with dropdown, Search button
- **MessageBubble**: White bg received bubbles (left-aligned) and sage green #C6D5BA sent bubbles (right-aligned) with improved SVG tails, 80% max-width, orange #FF9220 read receipt checkmarks, gray #8E8E93 delivered checks, 'edited' indicator before timestamp, muted timestamps
- **ChatViewPanel**: Subtle lavender #F5F3FF chat area background, 'last seen recently' fallback status, passes userId/chatId to header
- **DateSeparator**: Clean white/80 pill with muted text, backdrop blur
- **MessageInput**: 'Message' placeholder, rounded-2xl input, muted placeholder color

## Test plan

- [ ] Open a private chat and verify header shows ArrowLeft, avatar, name, status, Phone, kebab menu
- [ ] Verify sent messages use sage green background with right tail
- [ ] Verify received messages use white background with left tail
- [ ] Check timestamps appear in muted #8E8E93 color
- [ ] Check read receipts show orange double-check for read, gray single-check for delivered
- [ ] Verify date separators display as centered white pills
- [ ] Verify chat background is subtle lavender #F5F3FF
- [ ] Confirm message input shows 'Message' placeholder

Closes #105