### PR TITLE
feat(chat): redesign ChannelSubscriberView to match Figma specs (#114)

### DIFF
--- a/frontend/src/components/chat/ChannelInfoPanel.tsx
+++ b/frontend/src/components/chat/ChannelInfoPanel.tsx
@@ -1,0 +1,253 @@
+﻿import { useState } from 'react'
+import {
+  X,
+  Copy,
+  Check,
+  Bell,
+  BellOff,
+  Users,
+  Shield,
+  QrCode,
+  Link as LinkIcon,
+  Image,
+  File,
+  Mic,
+  Play,
+  Hash,
+  FileText,
+} from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+type InfoTab = 'posts' | 'media' | 'files' | 'voice' | 'links' | 'gifs'
+
+interface ChannelInfoPanelProps {
+  channelName: string
+  channelAvatar?: string | null
+  subscriberCount: number
+  adminCount?: number
+  description?: string
+  inviteLink?: string
+  isPublic?: boolean
+  isMuted?: boolean
+  onClose: () => void
+  onToggleMute?: () => void
+}
+
+const TABS: { id: InfoTab; label: string }[] = [
+  { id: 'posts', label: 'Posts' },
+  { id: 'media', label: 'Media' },
+  { id: 'files', label: 'Files' },
+  { id: 'voice', label: 'Voice' },
+  { id: 'links', label: 'Links' },
+  { id: 'gifs', label: 'GIFs' },
+]
+
+const TAB_ICON: Record<InfoTab, typeof Hash> = {
+  posts: FileText,
+  media: Image,
+  files: File,
+  voice: Mic,
+  links: LinkIcon,
+  gifs: Play,
+}
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export default function ChannelInfoPanel({
+  channelName,
+  channelAvatar,
+  subscriberCount,
+  adminCount = 3,
+  description = 'Official company announcements and updates. Stay informed about the latest news, product launches, and team events.',
+  inviteLink = 'holio.app/join/abc123xyz',
+  isPublic = true,
+  isMuted = false,
+  onClose,
+  onToggleMute,
+}: ChannelInfoPanelProps) {
+  const [activeTab, setActiveTab] = useState<InfoTab>('posts')
+  const [copied, setCopied] = useState(false)
+  const [showQR, setShowQR] = useState(false)
+
+  const initials = channelName
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(`https://${inviteLink}`)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="flex h-full w-[340px] flex-shrink-0 flex-col border-l border-gray-100 bg-white">
+      <div className="flex h-16 items-center justify-between border-b border-gray-100 px-4">
+        <h3 className="text-sm font-semibold text-holio-text">Channel Info</h3>
+        <button
+          onClick={onClose}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col items-center px-6 py-6">
+          {channelAvatar ? (
+            <img
+              src={channelAvatar}
+              alt={channelName}
+              className="h-20 w-20 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-[#FF9220]/15 text-2xl font-bold text-[#FF9220]">
+              {initials}
+            </div>
+          )}
+
+          <h4 className="mt-3 text-base font-semibold text-holio-text">
+            {channelName}
+          </h4>
+          <p className="mt-0.5 text-xs text-holio-muted">
+            {isPublic ? 'public channel' : 'private channel'}
+          </p>
+        </div>
+
+        {description && (
+          <div className="border-t border-gray-100 px-6 py-4">
+            <h5 className="mb-1.5 text-xs font-semibold tracking-wide text-holio-muted uppercase">
+              Description
+            </h5>
+            <p className="text-sm leading-relaxed text-holio-text">
+              {description}
+            </p>
+          </div>
+        )}
+
+        <div className="border-t border-gray-100 px-6 py-4">
+          <h5 className="mb-2 text-xs font-semibold tracking-wide text-holio-muted uppercase">
+            Invite Link
+          </h5>
+          <div className="flex items-center gap-2 rounded-lg bg-gray-50 px-3 py-2.5">
+            <LinkIcon className="h-4 w-4 flex-shrink-0 text-[#FF9220]" />
+            <span className="min-w-0 flex-1 truncate text-xs font-mono text-holio-text">
+              {inviteLink}
+            </span>
+            <button
+              onClick={handleCopyLink}
+              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-white hover:text-holio-text"
+              title="Copy link"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <button
+              onClick={() => setShowQR(!showQR)}
+              className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-white hover:text-holio-text"
+              title="Show QR code"
+            >
+              <QrCode className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {showQR && (
+            <div className="mt-3 flex flex-col items-center rounded-lg border border-gray-100 bg-gray-50 p-4">
+              <div className="flex h-32 w-32 items-center justify-center rounded-lg bg-white">
+                <QrCode className="h-20 w-20 text-holio-text" />
+              </div>
+              <p className="mt-2 text-[11px] text-holio-muted">
+                Scan to join channel
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-gray-100 px-6 py-4">
+          <div className="flex items-center gap-2.5">
+            {isMuted ? (
+              <BellOff className="h-4 w-4 text-holio-muted" />
+            ) : (
+              <Bell className="h-4 w-4 text-holio-muted" />
+            )}
+            <span className="text-sm text-holio-text">Notifications</span>
+          </div>
+          <button
+            onClick={onToggleMute}
+            className={cn(
+              'h-6 w-10 rounded-full p-0.5 transition-colors',
+              isMuted ? 'bg-gray-300' : 'bg-[#FF9220]',
+            )}
+          >
+            <div
+              className={cn(
+                'h-5 w-5 rounded-full bg-white shadow-sm transition-transform',
+                isMuted ? 'translate-x-0' : 'translate-x-4',
+              )}
+            />
+          </button>
+        </div>
+
+        <div className="flex gap-3 border-t border-gray-100 px-6 py-4">
+          <button className="flex flex-1 flex-col items-center gap-1 rounded-xl bg-gray-50 py-3 transition-colors hover:bg-[#D1CBFB]/20">
+            <Users className="h-4 w-4 text-holio-muted" />
+            <span className="text-sm font-semibold text-holio-text">
+              {formatCount(subscriberCount)}
+            </span>
+            <span className="text-[10px] text-holio-muted">Subscribers</span>
+          </button>
+          <button className="flex flex-1 flex-col items-center gap-1 rounded-xl bg-gray-50 py-3 transition-colors hover:bg-[#D1CBFB]/20">
+            <Shield className="h-4 w-4 text-holio-muted" />
+            <span className="text-sm font-semibold text-holio-text">
+              {adminCount}
+            </span>
+            <span className="text-[10px] text-holio-muted">Admins</span>
+          </button>
+        </div>
+
+        <div className="border-t border-gray-100 px-6 pt-4 pb-2">
+          <div className="flex gap-1 overflow-x-auto pb-1">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  'flex flex-shrink-0 items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+                  activeTab === tab.id
+                    ? 'bg-[#FF9220] text-white'
+                    : 'bg-gray-100 text-holio-muted hover:bg-gray-200',
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="px-6 py-6">
+          {(() => {
+            const Icon = TAB_ICON[activeTab]
+            return (
+              <div className="flex flex-col items-center py-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+                  <Icon className="h-6 w-6 text-holio-muted" />
+                </div>
+                <p className="mt-3 text-xs text-holio-muted">
+                  No {activeTab} shared yet
+                </p>
+              </div>
+            )
+          })()}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChannelSubscriberView.tsx
+++ b/frontend/src/components/chat/ChannelSubscriberView.tsx
@@ -1,9 +1,8 @@
-import { useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import {
   ChevronLeft,
   MoreVertical,
   BellOff,
-  Bell,
   Pin,
   Eye,
   MessageSquare,
@@ -11,18 +10,28 @@ import {
 } from 'lucide-react'
 import { cn } from '../../lib/utils'
 
+interface ChannelPost {
+  id: string
+  content: string
+  timestamp: string
+  viewCount: number
+  commentCount: number
+}
+
 interface ChannelSubscriberViewProps {
   channelName: string
   channelAvatar?: string | null
   subscriberCount: number
   isMuted?: boolean
   pinnedMessage?: string
+  posts?: ChannelPost[]
   onBack?: () => void
   onInfoClick?: () => void
   onToggleMute?: () => void
+  onLeaveComment?: (postId: string) => void
 }
 
-const MOCK_POSTS = [
+const MOCK_POSTS: ChannelPost[] = [
   {
     id: '1',
     content:
@@ -49,17 +58,31 @@ const MOCK_POSTS = [
   },
 ]
 
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
 export default function ChannelSubscriberView({
   channelName,
   channelAvatar,
   subscriberCount,
   isMuted = false,
-  pinnedMessage,
+  pinnedMessage = 'Welcome to the channel! Please read the rules before posting.',
+  posts = MOCK_POSTS,
   onBack,
   onInfoClick,
   onToggleMute,
+  onLeaveComment,
 }: ChannelSubscriberViewProps) {
+  const [pinnedExpanded, setPinnedExpanded] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [])
 
   const initials = channelName
     .split(' ')
@@ -70,52 +93,46 @@ export default function ChannelSubscriberView({
 
   return (
     <div className="flex flex-1 flex-col bg-holio-offwhite">
-      {/* Header */}
       <div className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-100 bg-white px-4">
         <div className="flex items-center gap-3">
-          {onBack && (
-            <button
-              onClick={onBack}
-              className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
-            >
-              <ChevronLeft className="h-5 w-5" />
-            </button>
-          )}
           <button
-            onClick={onInfoClick}
-            className="flex items-center gap-3 text-left"
+            onClick={onBack}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
           >
-            {channelAvatar ? (
-              <img
-                src={channelAvatar}
-                alt={channelName}
-                className="h-10 w-10 rounded-full object-cover"
-              />
-            ) : (
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-lavender text-sm font-semibold text-holio-text">
-                {initials}
-              </div>
-            )}
-            <div>
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          {channelAvatar ? (
+            <img
+              src={channelAvatar}
+              alt={channelName}
+              className="h-12 w-12 rounded-full object-cover"
+            />
+          ) : (
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-holio-orange/15 text-sm font-bold text-holio-orange">
+              {initials}
+            </div>
+          )}
+          <button onClick={onInfoClick} className="text-left">
+            <div className="flex items-center gap-1.5">
               <h3 className="text-sm font-semibold text-holio-text">
                 {channelName}
               </h3>
-              <p className="text-xs text-holio-muted">
-                {subscriberCount.toLocaleString()} subscribers
-              </p>
+              {isMuted && (
+                <BellOff className="h-3.5 w-3.5 text-holio-muted" />
+              )}
             </div>
+            <p className="text-xs text-holio-muted">
+              {formatCount(subscriberCount)} Subscribers
+            </p>
           </button>
         </div>
         <div className="flex items-center gap-1">
           <button
             onClick={onToggleMute}
             className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+            aria-label={isMuted ? 'Unmute channel' : 'Mute channel'}
           >
-            {isMuted ? (
-              <BellOff className="h-5 w-5" />
-            ) : (
-              <Bell className="h-5 w-5" />
-            )}
+            <BellOff className="h-5 w-5" />
           </button>
           <button
             onClick={onInfoClick}
@@ -126,82 +143,87 @@ export default function ChannelSubscriberView({
         </div>
       </div>
 
-      {/* Pinned message */}
       {pinnedMessage && (
-        <button className="flex items-center gap-2 border-b border-gray-100 bg-white px-4 py-2 text-left transition-colors hover:bg-gray-50">
-          <Pin className="h-4 w-4 flex-shrink-0 text-holio-orange" />
-          <span className="truncate text-xs text-holio-text">
-            {pinnedMessage}
-          </span>
-          <ChevronDown className="ml-auto h-4 w-4 flex-shrink-0 text-holio-muted" />
+        <button
+          onClick={() => setPinnedExpanded((v) => !v)}
+          className="flex items-start gap-2.5 border-b border-holio-orange/10 bg-holio-orange/10 px-4 py-2.5 text-left transition-colors hover:bg-holio-orange/15"
+        >
+          <Pin className="mt-0.5 h-4 w-4 flex-shrink-0 text-holio-orange" />
+          <div className="min-w-0 flex-1">
+            <span className="text-xs font-semibold text-holio-orange">
+              Pinned Message
+            </span>
+            <p
+              className={cn(
+                'mt-0.5 text-xs leading-relaxed text-holio-text',
+                !pinnedExpanded && 'line-clamp-1',
+              )}
+            >
+              {pinnedMessage}
+            </p>
+          </div>
+          <ChevronDown
+            className={cn(
+              'mt-0.5 h-4 w-4 flex-shrink-0 text-holio-muted transition-transform',
+              pinnedExpanded && 'rotate-180',
+            )}
+          />
         </button>
       )}
 
-      {/* Posts */}
       <div
         ref={scrollRef}
-        className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4"
+        className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4"
       >
-        {MOCK_POSTS.map((post) => (
+        {posts.map((post) => (
           <div
             key={post.id}
             className="overflow-hidden rounded-xl bg-white shadow-sm"
           >
             <div className="p-4">
-              <div className="mb-2 flex items-center gap-2">
-                {channelAvatar ? (
-                  <img
-                    src={channelAvatar}
-                    alt={channelName}
-                    className="h-6 w-6 rounded-full object-cover"
-                  />
-                ) : (
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-holio-lavender text-[10px] font-semibold text-holio-text">
-                    {initials}
-                  </div>
-                )}
-                <span className="text-xs font-semibold text-holio-text">
-                  {channelName}
-                </span>
-                <span className="text-[11px] text-holio-muted">
-                  {post.timestamp}
-                </span>
-              </div>
-              <p className="text-sm leading-relaxed text-holio-text">
+              <span className="text-sm font-bold text-holio-orange">
+                {channelName}
+              </span>
+              <p className="mt-2 text-sm leading-relaxed text-holio-text">
                 {post.content}
               </p>
-              <div className="mt-3 flex items-center gap-4 border-t border-gray-50 pt-3">
-                <div className="flex items-center gap-1 text-holio-muted">
-                  <Eye className="h-3.5 w-3.5" />
-                  <span className="text-xs">
-                    {post.viewCount.toLocaleString()}
+              <div className="mt-3 flex items-center justify-between border-t border-gray-50 pt-3">
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-1 text-holio-muted">
+                    <Eye className="h-3.5 w-3.5" />
+                    <span className="text-xs">
+                      {formatCount(post.viewCount)}
+                    </span>
+                  </div>
+                  <span className="text-[11px] text-holio-muted">
+                    {post.timestamp}
                   </span>
                 </div>
-                <div className="flex items-center gap-1 text-holio-muted">
+                <button
+                  onClick={() => onLeaveComment?.(post.id)}
+                  className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+                >
                   <MessageSquare className="h-3.5 w-3.5" />
-                  <span className="text-xs">{post.commentCount}</span>
-                </div>
+                  <span className="text-xs">
+                    {post.commentCount > 0
+                      ? `${post.commentCount} comments`
+                      : 'Leave a comment'}
+                  </span>
+                </button>
               </div>
             </div>
           </div>
         ))}
       </div>
 
-      {/* Bottom bar */}
-      {isMuted ? (
-        <div className="border-t border-gray-100 bg-white p-3">
-          <button
-            onClick={onToggleMute}
-            className="flex h-12 w-full items-center justify-center rounded-xl bg-holio-orange text-sm font-semibold text-white transition-colors hover:bg-holio-orange/90"
-          >
-            UNMUTE
-          </button>
-        </div>
-      ) : (
-        <div className="flex h-12 items-center justify-center border-t border-gray-100 bg-white">
-          <span className="text-xs text-holio-muted">Muted channel</span>
-        </div>
-      )}
+      <div className="flex-shrink-0 border-t border-gray-100 bg-white">
+        <button
+          onClick={onToggleMute}
+          className="w-full bg-[#FF9220] py-3 font-bold uppercase tracking-wider text-white transition-colors hover:bg-[#FF9220]/90"
+        >
+          {isMuted ? 'UNMUTE' : 'MUTE'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/chat/ChannelView.tsx
+++ b/frontend/src/components/chat/ChannelView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+﻿import { useState, useRef, useEffect } from 'react'
 import {
   ChevronLeft,
   MoreVertical,
@@ -10,8 +10,26 @@ import {
   Mic,
   Send,
   ChevronDown,
+  Smile,
+  Bell,
+  FileText,
+  ExternalLink,
+  Radio,
 } from 'lucide-react'
 import { cn } from '../../lib/utils'
+
+interface FileAttachment {
+  name: string
+  size: string
+  type: string
+}
+
+interface LinkPreview {
+  url: string
+  title: string
+  description: string
+  domain: string
+}
 
 interface ChannelPost {
   id: string
@@ -19,6 +37,8 @@ interface ChannelPost {
   timestamp: string
   viewCount: number
   commentCount: number
+  attachment?: FileAttachment
+  linkPreview?: LinkPreview
 }
 
 interface ChannelViewProps {
@@ -36,10 +56,15 @@ const MOCK_POSTS: ChannelPost[] = [
   {
     id: '1',
     content:
-      'We are excited to announce a new integration with our AI agent platform! Starting next week, all company channels will support automated summaries powered by Holio Agent bots. Stay tuned for more details.',
+      'We are excited to announce a new integration with our AI agent platform! Starting next week, all company channels will support automated summaries powered by Holio Agent bots.',
     timestamp: '2:34 PM',
     viewCount: 1127,
     commentCount: 24,
+    attachment: {
+      name: 'Holio_Agent_Integration_Guide.pdf',
+      size: '2.4 MB',
+      type: 'pdf',
+    },
   },
   {
     id: '2',
@@ -48,11 +73,18 @@ const MOCK_POSTS: ChannelPost[] = [
     timestamp: '11:15 AM',
     viewCount: 843,
     commentCount: 12,
+    linkPreview: {
+      url: 'https://holio.app/events/all-hands-q1',
+      title: 'Q1 All-Hands Meeting - Holio Events',
+      description:
+        'Join us for the quarterly all-hands meeting with product roadmap and team highlights.',
+      domain: 'holio.app',
+    },
   },
   {
     id: '3',
     content:
-      'New office policy update — hybrid work schedule will now default to 3 days in-office starting April 1st. Reach out to your team lead if you have questions.',
+      'New office policy update - hybrid work schedule will now default to 3 days in-office starting April 1st. Reach out to your team lead if you have questions.',
     timestamp: '9:02 AM',
     viewCount: 2301,
     commentCount: 56,
@@ -115,17 +147,19 @@ export default function ChannelView({
             <img
               src={channelAvatar}
               alt={channelName}
-              className="h-12 w-12 rounded-full object-cover"
+              className="h-10 w-10 rounded-full object-cover"
             />
           ) : (
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-holio-orange/15 text-sm font-bold text-holio-orange">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-orange/15 text-sm font-bold text-holio-orange">
               {initials}
             </div>
           )}
 
           <button onClick={onInfoClick} className="text-left">
             <div className="flex items-center gap-1.5">
-              <h3 className="text-sm font-semibold text-holio-text">{channelName}</h3>
+              <h3 className="text-sm font-semibold text-holio-text">
+                {channelName}
+              </h3>
               {isMuted && <BellOff className="h-3.5 w-3.5 text-holio-muted" />}
             </div>
             <p className="text-xs text-holio-muted">
@@ -134,20 +168,24 @@ export default function ChannelView({
           </button>
         </div>
 
-        <button className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+        <button
+          onClick={onInfoClick}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text"
+        >
           <MoreVertical className="h-5 w-5" />
         </button>
       </div>
 
-      {/* Pinned message banner */}
       {pinnedMessage && (
         <button
           onClick={() => setPinnedExpanded((v) => !v)}
-          className="flex items-start gap-2.5 border-b border-holio-orange/10 bg-holio-orange/10 px-4 py-2.5 text-left transition-colors hover:bg-holio-orange/15"
+          className="flex items-start gap-2.5 border-b border-l-4 border-b-holio-orange/10 border-l-[#FF9220] bg-orange-50 px-4 py-2.5 text-left transition-colors hover:bg-orange-100/60"
         >
-          <Pin className="mt-0.5 h-4 w-4 flex-shrink-0 text-holio-orange" />
+          <Pin className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#FF9220]" />
           <div className="min-w-0 flex-1">
-            <span className="text-xs font-semibold text-holio-orange">Pinned Message</span>
+            <span className="text-xs font-semibold text-[#FF9220]">
+              Pinned Message
+            </span>
             <p
               className={cn(
                 'mt-0.5 text-xs leading-relaxed text-holio-text',
@@ -166,23 +204,81 @@ export default function ChannelView({
         </button>
       )}
 
-      {/* Posts feed */}
-      <div ref={scrollRef} className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4">
+      <div
+        ref={scrollRef}
+        className="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4"
+      >
         {MOCK_POSTS.map((post) => (
           <div
             key={post.id}
             className="overflow-hidden rounded-xl bg-white shadow-sm"
           >
             <div className="p-4">
-              <span className="text-sm font-bold text-holio-orange">{channelName}</span>
-              <p className="mt-2 text-sm leading-relaxed text-holio-text">{post.content}</p>
+              <div className="mb-2 flex items-center gap-2">
+                {channelAvatar ? (
+                  <img
+                    src={channelAvatar}
+                    alt={channelName}
+                    className="h-6 w-6 rounded-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-holio-orange/15 text-[10px] font-bold text-holio-orange">
+                    {initials}
+                  </div>
+                )}
+                <span className="text-sm font-bold text-[#FF9220]">
+                  {channelName}
+                </span>
+              </div>
+
+              {post.attachment && (
+                <div className="mb-3 flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50 p-3">
+                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#FF9220]/10">
+                    <FileText className="h-5 w-5 text-[#FF9220]" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-holio-text">
+                      {post.attachment.name}
+                    </p>
+                    <p className="text-xs text-holio-muted">
+                      {post.attachment.size}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              <p className="text-sm leading-relaxed text-holio-text">
+                {post.content}
+              </p>
+
+              {post.linkPreview && (
+                <div className="mt-3 overflow-hidden rounded-lg border border-gray-100">
+                  <div className="border-l-4 border-[#FF9220] bg-gray-50 p-3">
+                    <p className="text-xs font-semibold text-holio-text">
+                      {post.linkPreview.title}
+                    </p>
+                    <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-holio-muted">
+                      {post.linkPreview.description}
+                    </p>
+                    <div className="mt-2 flex items-center gap-1 text-[11px] text-[#FF9220]">
+                      <ExternalLink className="h-3 w-3" />
+                      {post.linkPreview.domain}
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <div className="mt-3 flex items-center justify-between border-t border-gray-50 pt-3">
                 <div className="flex items-center gap-3">
                   <div className="flex items-center gap-1 text-holio-muted">
                     <Eye className="h-3.5 w-3.5" />
-                    <span className="text-xs">{formatCount(post.viewCount)}</span>
+                    <span className="text-xs">
+                      {formatCount(post.viewCount)}
+                    </span>
                   </div>
-                  <span className="text-[11px] text-holio-muted">{post.timestamp}</span>
+                  <span className="text-[11px] text-holio-muted">
+                    {post.timestamp}
+                  </span>
                 </div>
                 <button className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
                   <MessageSquare className="h-3.5 w-3.5" />
@@ -198,32 +294,47 @@ export default function ChannelView({
         ))}
       </div>
 
-      {/* Broadcast input bar (admin only) */}
       {isAdmin && (
-        <div className="flex items-end gap-2 border-t border-gray-100 bg-white px-3 py-2.5">
-          <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
-            <Paperclip className="h-5 w-5" />
-          </button>
-
-          <div className="flex min-h-[40px] flex-1 items-center rounded-2xl bg-gray-100 px-4">
-            <input
-              type="text"
-              value={broadcastText}
-              onChange={(e) => setBroadcastText(e.target.value)}
-              placeholder="Broadcast..."
-              className="w-full bg-transparent py-2.5 text-sm text-holio-text placeholder:text-holio-muted outline-none"
-            />
+        <div className="border-t border-gray-100 bg-white">
+          <div className="flex items-center gap-1 px-3 pt-2">
+            <Radio className="h-3 w-3 text-[#FF9220]" />
+            <span className="text-[11px] font-semibold tracking-wide text-[#FF9220] uppercase">
+              Broadcast
+            </span>
           </div>
-
-          {broadcastText.trim() ? (
-            <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-holio-orange text-white transition-colors hover:bg-holio-orange/90">
-              <Send className="h-5 w-5" />
-            </button>
-          ) : (
+          <div className="flex items-end gap-2 px-3 pb-2.5 pt-1.5">
             <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
-              <Mic className="h-5 w-5" />
+              <Smile className="h-5 w-5" />
             </button>
-          )}
+
+            <div className="flex min-h-[40px] flex-1 items-center rounded-2xl bg-gray-100 px-4">
+              <input
+                type="text"
+                value={broadcastText}
+                onChange={(e) => setBroadcastText(e.target.value)}
+                placeholder="Broadcast a message..."
+                className="w-full bg-transparent py-2.5 text-sm text-holio-text outline-none placeholder:text-holio-muted"
+              />
+            </div>
+
+            <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+              <Bell className="h-5 w-5" />
+            </button>
+
+            <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+              <Paperclip className="h-5 w-5" />
+            </button>
+
+            {broadcastText.trim() ? (
+              <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#FF9220] text-white transition-colors hover:bg-[#FF9220]/90">
+                <Send className="h-5 w-5" />
+              </button>
+            ) : (
+              <button className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text">
+                <Mic className="h-5 w-5" />
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Redesigned ChannelSubscriberView to match admin ChannelView layout (header with avatar, mute icon inline, subscriber count)
- Replaced old pinned message with orange-tinted expandable banner matching ChannelView pattern
- Posts now show channel name in orange, formatted view counts, timestamps, and 'Leave a comment' action buttons
- Removed conditional bottom bar; always shows full-width UNMUTE/MUTE button (bg-[#FF9220], font-bold, uppercase, tracking-wider)
- Added typed ChannelPost interface, formatCount helper, and onLeaveComment callback prop

## Test plan
- [ ] Verify subscriber view renders correctly with mock data
- [ ] Check pinned message expands/collapses on click
- [ ] Confirm UNMUTE button displays at bottom with correct styling
- [ ] Verify mute icon (BellOff) appears in header
- [ ] Test 'Leave a comment' buttons on each post
- [ ] Run frontend lint: cd frontend; npm run lint