### PR TITLE
feat(pages): add scroll collapse to ContactsListPage (#116)

### DIFF
--- a/frontend/src/components/layout/BottomNavBar.tsx
+++ b/frontend/src/components/layout/BottomNavBar.tsx
@@ -1,83 +1,82 @@
-import { MessageSquare, Users, Settings, Bot } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { MessageCircle, Users, Settings, Bot } from 'lucide-react'
 import { useUiStore, type NavItem } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { cn } from '../../lib/utils'
 
 type BottomTab = {
-  id: NavItem
+  id: NavItem | 'settings'
   label: string
-  icon: typeof MessageSquare
-  activeIcon: typeof MessageSquare
+  icon: typeof MessageCircle
+  route?: string
 }
 
 const TABS: BottomTab[] = [
-  { id: 'all', label: 'Chats', icon: MessageSquare, activeIcon: MessageSquare },
-  { id: 'contacts', label: 'Contacts', icon: Users, activeIcon: Users },
-  { id: 'bots', label: 'AI Agents', icon: Bot, activeIcon: Bot },
+  { id: 'all', label: 'Chats', icon: MessageCircle },
+  { id: 'contacts', label: 'Contacts', icon: Users, route: '/contacts' },
+  { id: 'settings', label: 'Settings', icon: Settings, route: '/settings' },
+  { id: 'bots', label: 'AI Agents', icon: Bot, route: '/bots' },
 ]
 
-const SETTINGS_TAB = { id: 'settings' as const, label: 'Settings', icon: Settings }
-
 export default function BottomNavBar() {
+  const navigate = useNavigate()
+  const location = useLocation()
   const activeNavItem = useUiStore((s) => s.activeNavItem)
   const setActiveNavItem = useUiStore((s) => s.setActiveNavItem)
   const chats = useChatStore((s) => s.chats)
 
   const totalUnread = chats.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0)
 
-  const handleTabPress = (id: NavItem | 'settings') => {
-    if (id === 'settings') {
-      window.location.href = '/settings'
-      return
-    }
-    setActiveNavItem(id)
+  const isActive = (tab: BottomTab) => {
+    if (tab.route) return location.pathname.startsWith(tab.route)
+    return activeNavItem === tab.id && location.pathname === '/'
   }
 
-  const isActive = (id: string) => activeNavItem === id
+  const handleTabPress = (tab: BottomTab) => {
+    if (tab.route) {
+      navigate(tab.route)
+    } else {
+      setActiveNavItem(tab.id as NavItem)
+      navigate('/')
+    }
+  }
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 flex border-t border-gray-200 bg-white md:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-4 border-t border-gray-200 bg-white md:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
       {TABS.map((tab) => {
-        const Icon = isActive(tab.id) ? tab.activeIcon : tab.icon
-        const active = isActive(tab.id)
+        const active = isActive(tab)
+        const Icon = tab.icon
         const showBadge = tab.id === 'all' && totalUnread > 0
 
         return (
           <button
             key={tab.id}
-            onClick={() => handleTabPress(tab.id)}
-            className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-            style={{ minHeight: 44, minWidth: 44 }}
+            onClick={() => handleTabPress(tab)}
+            className="relative flex flex-col items-center justify-center gap-0.5 py-2"
+            style={{ minHeight: 44 }}
           >
-            <div className="relative">
-              <div
+            <div className="relative flex items-center justify-center">
+              <Icon
                 className={cn(
-                  'flex items-center justify-center rounded-lg px-4 py-1 transition-colors',
-                  active && 'bg-holio-orange/15',
+                  'h-6 w-6 transition-colors',
+                  active ? 'text-holio-orange' : 'text-[#8E8E93]',
                 )}
-              >
-                <Icon
-                  className={cn(
-                    'h-6 w-6 transition-colors',
-                    active ? 'text-holio-orange' : 'text-gray-500',
-                  )}
-                  fill={active ? 'currentColor' : 'none'}
-                  strokeWidth={active ? 1.5 : 2}
-                />
-              </div>
+                fill={active ? 'currentColor' : 'none'}
+                strokeWidth={active ? 1.5 : 2}
+              />
               {showBadge && (
-                <span className="absolute -top-1 right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-medium leading-none text-white">
+                <span className="absolute -right-2.5 -top-1.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-semibold leading-none text-white">
                   {totalUnread > 99 ? '99+' : totalUnread}
                 </span>
               )}
             </div>
             <span
               className={cn(
-                'text-xs font-medium tracking-wide',
-                active ? 'text-holio-orange' : 'text-gray-500',
+                'text-[11px] font-medium',
+                active ? 'text-holio-orange' : 'text-[#8E8E93]',
               )}
             >
               {tab.label}
@@ -85,26 +84,6 @@ export default function BottomNavBar() {
           </button>
         )
       })}
-
-      <button
-        onClick={() => handleTabPress('settings')}
-        className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-        style={{ minHeight: 44, minWidth: 44 }}
-      >
-        <div
-          className={cn(
-            'flex items-center justify-center rounded-lg px-4 py-1',
-          )}
-        >
-          <SETTINGS_TAB.icon
-            className="h-6 w-6 text-gray-500 transition-colors"
-            strokeWidth={2}
-          />
-        </div>
-        <span className="text-xs font-medium tracking-wide text-gray-500">
-          {SETTINGS_TAB.label}
-        </span>
-      </button>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
- Contacts title shrinks from text-2xl to text-lg when scrolled past 80px threshold
- Action items section collapses with a smooth 300ms max-height/opacity transition
- Search icon remains accessible at all times in the sticky header
- Uses requestAnimationFrame throttling and will-change hints for jank-free performance

## Test plan
- [ ] Open Contacts page with enough contacts to scroll
- [ ] Scroll down past ~80px - title should smoothly shrink, action items should collapse
- [ ] Scroll back up - title and action items restore
- [ ] Tap search icon while collapsed - search bar still works
- [ ] Verify no visual jank during rapid scrolling

Closes #116

Made with [Cursor](https://cursor.com)