### PR TITLE
feat(router): wire UserProfile, SettingsAccount, Contacts, HolioPro routes (#126-#131)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,13 @@ import CompanySettingsPage from './pages/CompanySettingsPage'
 import ChatPage from './pages/ChatPage'
 import BotsPage from './pages/BotsPage'
 import SettingsPage from './pages/SettingsPage'
+import SettingsAccountPage from './pages/SettingsAccountPage'
 import EditProfilePage from './pages/EditProfilePage'
+import UserProfilePage from './pages/UserProfilePage'
+import ContactsListPage from './pages/ContactsListPage'
+import NewContactPage from './pages/NewContactPage'
+import HolioProDashboard from './pages/HolioProDashboard'
+import HolioProPage from './pages/HolioProPage'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -24,62 +30,19 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/verify" element={<VerifyPage />} />
         <Route path="/2fa" element={<TwoFactorPage />} />
-        <Route
-          path="/profile-setup"
-          element={
-            <ProtectedRoute>
-              <ProfileSetupPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/select-company"
-          element={
-            <ProtectedRoute>
-              <SelectCompanyPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/company-settings"
-          element={
-            <ProtectedRoute>
-              <CompanySettingsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/chat"
-          element={
-            <ProtectedRoute>
-              <ChatPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/bots"
-          element={
-            <ProtectedRoute>
-              <BotsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <ProtectedRoute>
-              <SettingsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/edit-profile"
-          element={
-            <ProtectedRoute>
-              <EditProfilePage />
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/profile-setup" element={<ProtectedRoute><ProfileSetupPage /></ProtectedRoute>} />
+        <Route path="/select-company" element={<ProtectedRoute><SelectCompanyPage /></ProtectedRoute>} />
+        <Route path="/company-settings" element={<ProtectedRoute><CompanySettingsPage /></ProtectedRoute>} />
+        <Route path="/chat" element={<ProtectedRoute><ChatPage /></ProtectedRoute>} />
+        <Route path="/bots" element={<ProtectedRoute><BotsPage /></ProtectedRoute>} />
+        <Route path="/settings/account" element={<ProtectedRoute><SettingsAccountPage /></ProtectedRoute>} />
+        <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+        <Route path="/edit-profile" element={<ProtectedRoute><EditProfilePage /></ProtectedRoute>} />
+        <Route path="/profile/:userId" element={<ProtectedRoute><UserProfilePage /></ProtectedRoute>} />
+        <Route path="/contacts/new" element={<ProtectedRoute><NewContactPage /></ProtectedRoute>} />
+        <Route path="/contacts" element={<ProtectedRoute><ContactsListPage /></ProtectedRoute>} />
+        <Route path="/holio-pro/dashboard" element={<ProtectedRoute><HolioProDashboard /></ProtectedRoute>} />
+        <Route path="/holio-pro" element={<ProtectedRoute><HolioProPage /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to="/chat" replace />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Summary
- Add 6 new protected route entries to App.tsx: `/profile/:userId`, `/settings/account`, `/contacts`, `/contacts/new`, `/holio-pro/dashboard`, `/holio-pro`
- Import the corresponding page components: UserProfilePage, SettingsAccountPage, ContactsListPage, NewContactPage, HolioProDashboard, HolioProPage
- Order specific routes before general ones (`/settings/account` before `/settings`, `/contacts/new` before `/contacts`, `/holio-pro/dashboard` before `/holio-pro`)

## Test plan
- [ ] Navigate to `/profile/:userId` and verify UserProfilePage renders
- [ ] Navigate to `/settings/account` and verify SettingsAccountPage renders
- [ ] Navigate to `/contacts` and verify ContactsListPage renders
- [ ] Navigate to `/contacts/new` and verify NewContactPage renders
- [ ] Navigate to `/holio-pro/dashboard` and verify HolioProDashboard renders
- [ ] Navigate to `/holio-pro` and verify HolioProPage renders
- [ ] Verify unauthenticated users are redirected to `/login`

Closes #126, Closes #127, Closes #128, Closes #129, Closes #130, Closes #131