### PR TITLE
feat(pages): build StoryPage with story viewer UI (#132)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,24 @@ import ChatPage from './pages/ChatPage'
 import BotsPage from './pages/BotsPage'
 import SettingsPage from './pages/SettingsPage'
 import EditProfilePage from './pages/EditProfilePage'
+import SettingsAccountPage from './pages/SettingsAccountPage'
+import SettingsNotificationsPage from './pages/SettingsNotificationsPage'
+import SettingsChatAppearancePage from './pages/SettingsChatAppearancePage'
+import SettingsDataStoragePage from './pages/SettingsDataStoragePage'
+import SettingsDevicesPage from './pages/SettingsDevicesPage'
+import SettingsFoldersPage from './pages/SettingsFoldersPage'
+import ContactsListPage from './pages/ContactsListPage'
+import NewContactPage from './pages/NewContactPage'
+import BlockedContactsPage from './pages/BlockedContactsPage'
+import UserProfilePage from './pages/UserProfilePage'
+import SavedMessagesPage from './pages/SavedMessagesPage'
+import RecentCallsPage from './pages/RecentCallsPage'
+import StoryPage from './pages/StoryPage'
+import IntegrationsPage from './pages/IntegrationsPage'
+import InviteFriendsPage from './pages/InviteFriendsPage'
+import NearbyPeoplePage from './pages/NearbyPeoplePage'
+import HolioProPage from './pages/HolioProPage'
+import HolioProDashboard from './pages/HolioProDashboard'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
@@ -24,62 +42,31 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/verify" element={<VerifyPage />} />
         <Route path="/2fa" element={<TwoFactorPage />} />
-        <Route
-          path="/profile-setup"
-          element={
-            <ProtectedRoute>
-              <ProfileSetupPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/select-company"
-          element={
-            <ProtectedRoute>
-              <SelectCompanyPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/company-settings"
-          element={
-            <ProtectedRoute>
-              <CompanySettingsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/chat"
-          element={
-            <ProtectedRoute>
-              <ChatPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/bots"
-          element={
-            <ProtectedRoute>
-              <BotsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/settings"
-          element={
-            <ProtectedRoute>
-              <SettingsPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/edit-profile"
-          element={
-            <ProtectedRoute>
-              <EditProfilePage />
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/profile-setup" element={<ProtectedRoute><ProfileSetupPage /></ProtectedRoute>} />
+        <Route path="/select-company" element={<ProtectedRoute><SelectCompanyPage /></ProtectedRoute>} />
+        <Route path="/company-settings" element={<ProtectedRoute><CompanySettingsPage /></ProtectedRoute>} />
+        <Route path="/chat" element={<ProtectedRoute><ChatPage /></ProtectedRoute>} />
+        <Route path="/bots" element={<ProtectedRoute><BotsPage /></ProtectedRoute>} />
+        <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
+        <Route path="/settings/account" element={<ProtectedRoute><SettingsAccountPage /></ProtectedRoute>} />
+        <Route path="/settings/notifications" element={<ProtectedRoute><SettingsNotificationsPage /></ProtectedRoute>} />
+        <Route path="/settings/appearance" element={<ProtectedRoute><SettingsChatAppearancePage /></ProtectedRoute>} />
+        <Route path="/settings/data-storage" element={<ProtectedRoute><SettingsDataStoragePage /></ProtectedRoute>} />
+        <Route path="/settings/devices" element={<ProtectedRoute><SettingsDevicesPage /></ProtectedRoute>} />
+        <Route path="/settings/folders" element={<ProtectedRoute><SettingsFoldersPage /></ProtectedRoute>} />
+        <Route path="/edit-profile" element={<ProtectedRoute><EditProfilePage /></ProtectedRoute>} />
+        <Route path="/profile/:userId" element={<ProtectedRoute><UserProfilePage /></ProtectedRoute>} />
+        <Route path="/contacts/new" element={<ProtectedRoute><NewContactPage /></ProtectedRoute>} />
+        <Route path="/contacts/blocked" element={<ProtectedRoute><BlockedContactsPage /></ProtectedRoute>} />
+        <Route path="/contacts" element={<ProtectedRoute><ContactsListPage /></ProtectedRoute>} />
+        <Route path="/saved-messages" element={<ProtectedRoute><SavedMessagesPage /></ProtectedRoute>} />
+        <Route path="/calls" element={<ProtectedRoute><RecentCallsPage /></ProtectedRoute>} />
+        <Route path="/stories" element={<ProtectedRoute><StoryPage /></ProtectedRoute>} />
+        <Route path="/integrations" element={<ProtectedRoute><IntegrationsPage /></ProtectedRoute>} />
+        <Route path="/invite-friends" element={<ProtectedRoute><InviteFriendsPage /></ProtectedRoute>} />
+        <Route path="/nearby" element={<ProtectedRoute><NearbyPeoplePage /></ProtectedRoute>} />
+        <Route path="/holio-pro/dashboard" element={<ProtectedRoute><HolioProDashboard /></ProtectedRoute>} />
+        <Route path="/holio-pro" element={<ProtectedRoute><HolioProPage /></ProtectedRoute>} />
         <Route path="*" element={<Navigate to="/chat" replace />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/layout/BottomNavBar.tsx
+++ b/frontend/src/components/layout/BottomNavBar.tsx
@@ -1,83 +1,82 @@
-import { MessageSquare, Users, Settings, Bot } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { MessageCircle, Users, Settings, Bot } from 'lucide-react'
 import { useUiStore, type NavItem } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { cn } from '../../lib/utils'
 
 type BottomTab = {
-  id: NavItem
+  id: NavItem | 'settings'
   label: string
-  icon: typeof MessageSquare
-  activeIcon: typeof MessageSquare
+  icon: typeof MessageCircle
+  route?: string
 }
 
 const TABS: BottomTab[] = [
-  { id: 'all', label: 'Chats', icon: MessageSquare, activeIcon: MessageSquare },
-  { id: 'contacts', label: 'Contacts', icon: Users, activeIcon: Users },
-  { id: 'bots', label: 'AI Agents', icon: Bot, activeIcon: Bot },
+  { id: 'all', label: 'Chats', icon: MessageCircle },
+  { id: 'contacts', label: 'Contacts', icon: Users, route: '/contacts' },
+  { id: 'settings', label: 'Settings', icon: Settings, route: '/settings' },
+  { id: 'bots', label: 'AI Agents', icon: Bot, route: '/bots' },
 ]
 
-const SETTINGS_TAB = { id: 'settings' as const, label: 'Settings', icon: Settings }
-
 export default function BottomNavBar() {
+  const navigate = useNavigate()
+  const location = useLocation()
   const activeNavItem = useUiStore((s) => s.activeNavItem)
   const setActiveNavItem = useUiStore((s) => s.setActiveNavItem)
   const chats = useChatStore((s) => s.chats)
 
   const totalUnread = chats.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0)
 
-  const handleTabPress = (id: NavItem | 'settings') => {
-    if (id === 'settings') {
-      window.location.href = '/settings'
-      return
-    }
-    setActiveNavItem(id)
+  const isActive = (tab: BottomTab) => {
+    if (tab.route) return location.pathname.startsWith(tab.route)
+    return activeNavItem === tab.id && location.pathname === '/'
   }
 
-  const isActive = (id: string) => activeNavItem === id
+  const handleTabPress = (tab: BottomTab) => {
+    if (tab.route) {
+      navigate(tab.route)
+    } else {
+      setActiveNavItem(tab.id as NavItem)
+      navigate('/')
+    }
+  }
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 flex border-t border-gray-200 bg-white md:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-4 border-t border-gray-200 bg-white md:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
       {TABS.map((tab) => {
-        const Icon = isActive(tab.id) ? tab.activeIcon : tab.icon
-        const active = isActive(tab.id)
+        const active = isActive(tab)
+        const Icon = tab.icon
         const showBadge = tab.id === 'all' && totalUnread > 0
 
         return (
           <button
             key={tab.id}
-            onClick={() => handleTabPress(tab.id)}
-            className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-            style={{ minHeight: 44, minWidth: 44 }}
+            onClick={() => handleTabPress(tab)}
+            className="relative flex flex-col items-center justify-center gap-0.5 py-2"
+            style={{ minHeight: 44 }}
           >
-            <div className="relative">
-              <div
+            <div className="relative flex items-center justify-center">
+              <Icon
                 className={cn(
-                  'flex items-center justify-center rounded-lg px-4 py-1 transition-colors',
-                  active && 'bg-holio-orange/15',
+                  'h-6 w-6 transition-colors',
+                  active ? 'text-holio-orange' : 'text-[#8E8E93]',
                 )}
-              >
-                <Icon
-                  className={cn(
-                    'h-6 w-6 transition-colors',
-                    active ? 'text-holio-orange' : 'text-gray-500',
-                  )}
-                  fill={active ? 'currentColor' : 'none'}
-                  strokeWidth={active ? 1.5 : 2}
-                />
-              </div>
+                fill={active ? 'currentColor' : 'none'}
+                strokeWidth={active ? 1.5 : 2}
+              />
               {showBadge && (
-                <span className="absolute -top-1 right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-medium leading-none text-white">
+                <span className="absolute -right-2.5 -top-1.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-semibold leading-none text-white">
                   {totalUnread > 99 ? '99+' : totalUnread}
                 </span>
               )}
             </div>
             <span
               className={cn(
-                'text-xs font-medium tracking-wide',
-                active ? 'text-holio-orange' : 'text-gray-500',
+                'text-[11px] font-medium',
+                active ? 'text-holio-orange' : 'text-[#8E8E93]',
               )}
             >
               {tab.label}
@@ -85,26 +84,6 @@ export default function BottomNavBar() {
           </button>
         )
       })}
-
-      <button
-        onClick={() => handleTabPress('settings')}
-        className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-        style={{ minHeight: 44, minWidth: 44 }}
-      >
-        <div
-          className={cn(
-            'flex items-center justify-center rounded-lg px-4 py-1',
-          )}
-        >
-          <SETTINGS_TAB.icon
-            className="h-6 w-6 text-gray-500 transition-colors"
-            strokeWidth={2}
-          />
-        </div>
-        <span className="text-xs font-medium tracking-wide text-gray-500">
-          {SETTINGS_TAB.label}
-        </span>
-      </button>
     </nav>
   )
 }

--- a/frontend/src/pages/BlockedContactsPage.tsx
+++ b/frontend/src/pages/BlockedContactsPage.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, ShieldOff, User } from 'lucide-react'
+import { useContactsStore } from '../stores/contactsStore'
+import { cn } from '../lib/utils'
+
+export default function BlockedContactsPage() {
+  const navigate = useNavigate()
+  const { blocked, fetchBlocked, unblockUser } = useContactsStore()
+  const [unblocking, setUnblocking] = useState<Set<string>>(new Set())
+
+  useEffect(() => { fetchBlocked() }, [fetchBlocked])
+
+  const handleUnblock = async (userId: string) => {
+    setUnblocking((s) => new Set(s).add(userId))
+    try {
+      await unblockUser(userId)
+    } catch { /* silent */ }
+    setUnblocking((s) => { const n = new Set(s); n.delete(userId); return n })
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-[#FCFCF8]">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button onClick={() => navigate(-1)} className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100">
+          <ChevronLeft className="h-5 w-5 text-[#1A1A1A]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[#1A1A1A]">Blocked Contacts</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto pb-8">
+        <div className="mx-4 mb-4 rounded-xl bg-[#D1CBFB]/10 p-4">
+          <p className="text-xs text-[#1A1A1A]">
+            Blocked users can't send you messages, add you to groups, or see your last seen and profile photo.
+          </p>
+        </div>
+
+        {blocked.length === 0 ? (
+          <div className="flex flex-col items-center justify-center px-4 py-20">
+            <ShieldOff className="mb-3 h-14 w-14 text-[#8E8E93]/25" />
+            <p className="text-base font-medium text-[#1A1A1A]">No blocked contacts</p>
+            <p className="mt-1 text-sm text-[#8E8E93]">Users you block will appear here</p>
+          </div>
+        ) : (
+          <div className="mx-4 rounded-2xl bg-white">
+            {blocked.map((contact, i) => {
+              const user = contact.contactUser
+              const name = [user?.firstName, user?.lastName].filter(Boolean).join(' ') || 'Unknown'
+              return (
+                <div key={contact.id}>
+                  {i > 0 && <div className="mx-4 border-t border-gray-100" />}
+                  <div className="flex items-center gap-3 px-4 py-3">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#D1CBFB]/20">
+                      {user?.avatarUrl ? (
+                        <img src={user.avatarUrl} alt="" className="h-full w-full object-cover" />
+                      ) : (
+                        <User className="h-5 w-5 text-[#D1CBFB]" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-[#1A1A1A]">{name}</p>
+                      {user?.phone && <p className="text-xs text-[#8E8E93]">{user.phone}</p>}
+                    </div>
+                    <button
+                      onClick={() => handleUnblock(contact.contactUserId)}
+                      disabled={unblocking.has(contact.contactUserId)}
+                      className={cn('rounded-lg px-3 py-1.5 text-xs font-medium text-[#FF9220] hover:bg-[#FF9220]/10 disabled:opacity-50')}
+                    >
+                      {unblocking.has(contact.contactUserId) ? 'Unblocking...' : 'Unblock'}
+                    </button>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/InviteFriendsPage.tsx
+++ b/frontend/src/pages/InviteFriendsPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, Share2, Copy, Mail, MessageSquare, Link, Check } from 'lucide-react'
+import { useAuthStore } from '../stores/authStore'
+
+export default function InviteFriendsPage() {
+  const navigate = useNavigate()
+  const user = useAuthStore((s) => s.user)
+  const [copiedLink, setCopiedLink] = useState(false)
+  const [copiedUsername, setCopiedUsername] = useState(false)
+
+  const inviteLink = `https://holio.app/join/${user?.username || 'user'}`
+  const username = user?.username ? `@${user.username}` : '@user'
+
+  const copyToClipboard = async (text: string, type: 'link' | 'username') => {
+    try {
+      await navigator.clipboard.writeText(text)
+      if (type === 'link') { setCopiedLink(true); setTimeout(() => setCopiedLink(false), 2000) }
+      else { setCopiedUsername(true); setTimeout(() => setCopiedUsername(false), 2000) }
+    } catch { /* silent */ }
+  }
+
+  const shareMessage = async () => {
+    if (navigator.share) {
+      try { await navigator.share({ title: 'Join me on Holio', text: `Chat with me on Holio Agent! ${inviteLink}`, url: inviteLink }) } catch { /* silent */ }
+    } else {
+      copyToClipboard(inviteLink, 'link')
+    }
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-[#FCFCF8]">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button onClick={() => navigate(-1)} className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100">
+          <ChevronLeft className="h-5 w-5 text-[#1A1A1A]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[#1A1A1A]">Invite Friends</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto pb-8">
+        <div className="mx-4 rounded-2xl bg-gradient-to-br from-[#D1CBFB] to-[#FF9220] p-6 text-center text-white">
+          <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
+            <Share2 className="h-8 w-8" />
+          </div>
+          <h2 className="text-xl font-bold">Invite Friends to Holio</h2>
+          <p className="mt-1 text-sm text-white/80">Share your invite link and connect with your team</p>
+        </div>
+
+        <p className="px-4 pt-5 pb-1 text-xs font-semibold uppercase tracking-wider text-[#8E8E93]">Your Invite Link</p>
+        <div className="mx-4 rounded-2xl bg-white p-4">
+          <div className="flex items-center gap-3">
+            <Link className="h-4 w-4 flex-shrink-0 text-[#8E8E93]" />
+            <span className="min-w-0 flex-1 truncate text-sm text-[#1A1A1A]">{inviteLink}</span>
+            <button onClick={() => copyToClipboard(inviteLink, 'link')} className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-[#FF9220]/10 text-[#FF9220] hover:bg-[#FF9220]/20">
+              {copiedLink ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </button>
+          </div>
+          {copiedLink && <p className="mt-1 text-right text-xs text-green-600">Copied!</p>}
+        </div>
+
+        <p className="px-4 pt-5 pb-1 text-xs font-semibold uppercase tracking-wider text-[#8E8E93]">Share Via</p>
+        <div className="mx-4 rounded-2xl bg-white">
+          <button onClick={() => copyToClipboard(inviteLink, 'link')} className="flex w-full items-center gap-3 px-4 py-3 hover:bg-gray-50">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#FF9220]/10">
+              <Copy className="h-4 w-4 text-[#FF9220]" />
+            </div>
+            <span className="text-sm text-[#1A1A1A]">Copy Link</span>
+          </button>
+          <div className="mx-4 border-t border-gray-100" />
+          <button onClick={shareMessage} className="flex w-full items-center gap-3 px-4 py-3 hover:bg-gray-50">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50">
+              <MessageSquare className="h-4 w-4 text-blue-500" />
+            </div>
+            <span className="text-sm text-[#1A1A1A]">Share Message</span>
+          </button>
+          <div className="mx-4 border-t border-gray-100" />
+          <a href={`mailto:?subject=Join me on Holio&body=Chat with me on Holio Agent! ${encodeURIComponent(inviteLink)}`} className="flex w-full items-center gap-3 px-4 py-3 hover:bg-gray-50">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-green-50">
+              <Mail className="h-4 w-4 text-green-500" />
+            </div>
+            <span className="text-sm text-[#1A1A1A]">Email</span>
+          </a>
+        </div>
+
+        <p className="px-4 pt-5 pb-1 text-xs font-semibold uppercase tracking-wider text-[#8E8E93]">Your Username</p>
+        <div className="mx-4 rounded-2xl bg-white p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-[#1A1A1A]">{username}</span>
+            <button onClick={() => copyToClipboard(username, 'username')} className="flex items-center gap-1 text-xs font-medium text-[#FF9220]">
+              {copiedUsername ? <><Check className="h-3.5 w-3.5" /> Copied!</> : <><Copy className="h-3.5 w-3.5" /> Copy</>}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/NearbyPeoplePage.tsx
+++ b/frontend/src/pages/NearbyPeoplePage.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, Radar, MapPin, Users, User } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+const DEMO_USERS = [
+  { id: '1', name: 'Anders Berg', distance: '~200m away' },
+  { id: '2', name: 'Ingrid Haugen', distance: '~500m away' },
+  { id: '3', name: 'Lars Eriksen', distance: '~1.2km away' },
+]
+
+const DEMO_GROUPS = [
+  { id: '1', name: 'Oslo Tech Meetup', members: 48, distance: '~300m' },
+  { id: '2', name: 'Downtown Coffee Club', members: 15, distance: '~800m' },
+]
+
+export default function NearbyPeoplePage() {
+  const navigate = useNavigate()
+  const [visible, setVisible] = useState(false)
+
+  return (
+    <div className="flex h-screen flex-col bg-[#FCFCF8]">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button onClick={() => navigate(-1)} className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100">
+          <ChevronLeft className="h-5 w-5 text-[#1A1A1A]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[#1A1A1A]">People Nearby</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto pb-8">
+        <div className="mx-4 mb-4 flex flex-col items-center rounded-2xl bg-white p-6">
+          <div className="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-[#FF9220]/10">
+            <Radar className="h-8 w-8 text-[#FF9220]" />
+          </div>
+          <h2 className="text-base font-semibold text-[#1A1A1A]">Find People Nearby</h2>
+          <p className="mt-1 text-center text-sm text-[#8E8E93]">Make yourself visible to discover and be discovered by people around you</p>
+          <button
+            onClick={() => setVisible(!visible)}
+            className={cn('mt-4 w-full rounded-xl py-3 text-sm font-semibold transition-colors', visible ? 'bg-red-50 text-red-600 hover:bg-red-100' : 'bg-[#FF9220] text-white hover:bg-orange-500')}
+          >
+            {visible ? 'Stop Sharing Location' : 'Make Myself Visible'}
+          </button>
+        </div>
+
+        {visible && (
+          <>
+            <p className="px-4 pt-2 pb-1 text-xs font-semibold uppercase tracking-wider text-[#8E8E93]">People Nearby</p>
+            <div className="mx-4 rounded-2xl bg-white">
+              {DEMO_USERS.map((u, i) => (
+                <div key={u.id}>
+                  {i > 0 && <div className="mx-4 border-t border-gray-100" />}
+                  <div className="flex items-center gap-3 px-4 py-3">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#D1CBFB]/20">
+                      <User className="h-5 w-5 text-[#D1CBFB]" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-[#1A1A1A]">{u.name}</p>
+                      <div className="flex items-center gap-1">
+                        <MapPin className="h-3 w-3 text-[#8E8E93]" />
+                        <span className="text-xs text-[#8E8E93]">{u.distance}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <p className="px-4 pt-5 pb-1 text-xs font-semibold uppercase tracking-wider text-[#8E8E93]">Nearby Groups</p>
+            <div className="mx-4 rounded-2xl bg-white">
+              {DEMO_GROUPS.map((g, i) => (
+                <div key={g.id}>
+                  {i > 0 && <div className="mx-4 border-t border-gray-100" />}
+                  <div className="flex items-center gap-3 px-4 py-3">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#C6D5BA]/30">
+                      <Users className="h-5 w-5 text-[#C6D5BA]" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-[#1A1A1A]">{g.name}</p>
+                      <div className="flex items-center gap-2 text-xs text-[#8E8E93]">
+                        <span>{g.members} members</span>
+                        <span>•</span>
+                        <span>{g.distance}</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div className="mx-4 mt-5 rounded-xl bg-[#D1CBFB]/10 p-4">
+          <p className="text-xs text-[#8E8E93]">
+            Your approximate distance is shared while visible. Exact location is never revealed to other users.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/RecentCallsPage.tsx
+++ b/frontend/src/pages/RecentCallsPage.tsx
@@ -1,0 +1,67 @@
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, PhoneIncoming, PhoneOutgoing, PhoneMissed, Phone, Video } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+const DEMO_CALLS = [
+  { id: 1, name: 'Alice Johnson', type: 'incoming' as const, callType: 'voice' as const, date: 'Today, 2:30 PM', duration: '5:23' },
+  { id: 2, name: 'Bob Smith', type: 'outgoing' as const, callType: 'video' as const, date: 'Today, 11:15 AM', duration: '12:45' },
+  { id: 3, name: 'Carol Williams', type: 'missed' as const, callType: 'voice' as const, date: 'Yesterday, 6:00 PM', duration: '' },
+  { id: 4, name: 'David Brown', type: 'incoming' as const, callType: 'voice' as const, date: 'Yesterday, 3:20 PM', duration: '1:02' },
+  { id: 5, name: 'Emma Davis', type: 'outgoing' as const, callType: 'video' as const, date: 'Mar 27, 9:00 AM', duration: '23:10' },
+  { id: 6, name: 'Frank Miller', type: 'missed' as const, callType: 'voice' as const, date: 'Mar 26, 4:45 PM', duration: '' },
+]
+
+const ICONS = { incoming: PhoneIncoming, outgoing: PhoneOutgoing, missed: PhoneMissed }
+const COLORS = { incoming: 'text-green-500', outgoing: 'text-blue-500', missed: 'text-red-500' }
+const LABELS = { incoming: 'Incoming', outgoing: 'Outgoing', missed: 'Missed' }
+
+export default function RecentCallsPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex h-screen flex-col bg-[#FCFCF8]">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button onClick={() => navigate(-1)} className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100">
+          <ChevronLeft className="h-5 w-5 text-[#1A1A1A]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[#1A1A1A]">Recent Calls</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto pb-8">
+        <div className="mx-4 rounded-2xl bg-white">
+          {DEMO_CALLS.map((call, i) => {
+            const DirIcon = ICONS[call.type]
+            const initials = call.name.split(' ').map((w) => w[0]).join('')
+            return (
+              <div key={call.id}>
+                {i > 0 && <div className="mx-4 border-t border-gray-100" />}
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#D1CBFB]/20">
+                    <span className="text-sm font-semibold text-[#D1CBFB]">{initials}</span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className={cn('text-sm font-medium', call.type === 'missed' ? 'text-red-500' : 'text-[#1A1A1A]')}>{call.name}</p>
+                    <div className="flex items-center gap-1.5">
+                      <DirIcon className={cn('h-3 w-3', COLORS[call.type])} />
+                      <span className="text-xs text-[#8E8E93]">
+                        {LABELS[call.type]}{call.duration ? ` • ${call.duration}` : ''}
+                      </span>
+                    </div>
+                    <p className="text-xs text-[#8E8E93]">{call.date}</p>
+                  </div>
+                  <button className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full hover:bg-gray-100">
+                    {call.callType === 'video' ? <Video className="h-4.5 w-4.5 text-[#FF9220]" /> : <Phone className="h-4.5 w-4.5 text-[#FF9220]" />}
+                  </button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <p className="mt-6 px-4 text-center text-xs text-[#8E8E93]">
+          Voice &amp; video calling is coming soon.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/SavedMessagesPage.tsx
+++ b/frontend/src/pages/SavedMessagesPage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, Bookmark, Trash2, FileText, Image as ImageIcon } from 'lucide-react'
+import api from '../services/api.service'
+import { cn } from '../lib/utils'
+
+interface SavedMessage {
+  id: string
+  content: string
+  type: 'text' | 'image' | 'file'
+  chatName: string
+  fileName?: string
+  imageUrl?: string
+  createdAt: string
+}
+
+export default function SavedMessagesPage() {
+  const navigate = useNavigate()
+  const [messages, setMessages] = useState<SavedMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    api.get<SavedMessage[]>('/saved-messages')
+      .then(({ data }) => setMessages(data))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const unsave = async (id: string) => {
+    setDeletingIds((s) => new Set(s).add(id))
+    try {
+      await api.delete(`/saved-messages/${id}`)
+      setMessages((m) => m.filter((msg) => msg.id !== id))
+    } catch { /* silent */ }
+    setDeletingIds((s) => { const n = new Set(s); n.delete(id); return n })
+  }
+
+  const formatDate = (iso: string) => {
+    const d = new Date(iso)
+    const now = new Date()
+    if (d.toDateString() === now.toDateString()) return `Today, ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+    const yesterday = new Date(now); yesterday.setDate(yesterday.getDate() - 1)
+    if (d.toDateString() === yesterday.toDateString()) return `Yesterday, ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' })
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-[#FCFCF8]">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button onClick={() => navigate(-1)} className="flex h-8 w-8 items-center justify-center rounded-full hover:bg-gray-100">
+          <ChevronLeft className="h-5 w-5 text-[#1A1A1A]" />
+        </button>
+        <h1 className="text-lg font-semibold text-[#1A1A1A]">Saved Messages</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto pb-8">
+        {loading && (
+          <div className="flex justify-center py-16">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#FF9220] border-t-transparent" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="px-4 py-16 text-center">
+            <p className="text-sm text-red-500">Failed to load saved messages</p>
+            <button onClick={() => window.location.reload()} className="mt-2 text-sm font-medium text-[#FF9220]">Retry</button>
+          </div>
+        )}
+
+        {!loading && !error && messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center px-4 py-20">
+            <Bookmark className="mb-3 h-14 w-14 text-[#8E8E93]/25" />
+            <p className="text-base font-medium text-[#1A1A1A]">No saved messages</p>
+            <p className="mt-1 text-sm text-[#8E8E93]">Messages you save will appear here</p>
+          </div>
+        )}
+
+        {!loading && !error && messages.length > 0 && (
+          <div className="space-y-3 px-4">
+            {messages.map((msg) => (
+              <div key={msg.id} className={cn('rounded-2xl bg-white p-4 shadow-sm', deletingIds.has(msg.id) && 'opacity-50')}>
+                <div className="mb-2 flex items-center justify-between">
+                  <span className="text-xs font-medium text-[#FF9220]">{msg.chatName}</span>
+                  <span className="text-xs text-[#8E8E93]">{formatDate(msg.createdAt)}</span>
+                </div>
+                {msg.type === 'text' && (
+                  <p className="line-clamp-2 text-sm text-[#1A1A1A]">{msg.content}</p>
+                )}
+                {msg.type === 'image' && (
+                  <div className="flex items-center gap-2">
+                    <ImageIcon className="h-4 w-4 text-[#8E8E93]" />
+                    <span className="text-sm text-[#1A1A1A]">Photo</span>
+                  </div>
+                )}
+                {msg.type === 'file' && (
+                  <div className="flex items-center gap-2">
+                    <FileText className="h-4 w-4 text-[#8E8E93]" />
+                    <span className="text-sm text-[#1A1A1A]">{msg.fileName || 'File'}</span>
+                  </div>
+                )}
+                <div className="mt-3 flex justify-end">
+                  <button onClick={() => unsave(msg.id)} disabled={deletingIds.has(msg.id)} className="flex items-center gap-1 text-xs text-red-500 hover:text-red-600 disabled:opacity-50">
+                    <Trash2 className="h-3.5 w-3.5" /> Unsave
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StoryPage.tsx
+++ b/frontend/src/pages/StoryPage.tsx
@@ -1,1 +1,126 @@
-// placeholder
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  ArrowLeft,
+  Bookmark,
+  Paperclip,
+  Smile,
+  Type,
+  SlidersHorizontal,
+  ChevronRight,
+  Clock,
+} from 'lucide-react'
+
+interface LinkPreviewData {
+  title: string
+  description: string
+  domain: string
+  image?: string
+}
+
+export default function StoryPage() {
+  const navigate = useNavigate()
+  const [caption, setCaption] = useState('')
+
+  const samplePreview: LinkPreviewData = {
+    title: 'Understanding Modern AI Agents',
+    description:
+      'A deep dive into how AI agents are transforming enterprise workflows and team collaboration.',
+    domain: 'blog.holio.ai',
+    image: 'https://picsum.photos/seed/story/120/80',
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-holio-dark">
+      {/* Header */}
+      <header className="flex flex-shrink-0 items-center justify-between px-4 py-3">
+        <button
+          onClick={() => navigate(-1)}
+          className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10"
+        >
+          <ArrowLeft className="h-6 w-6 text-white" />
+        </button>
+        <h1 className="text-lg font-semibold text-white">New Story</h1>
+        <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
+          <Bookmark className="h-5 w-5 text-white" />
+        </button>
+      </header>
+
+      {/* Content area */}
+      <div className="flex flex-1 flex-col items-center justify-center px-4">
+        <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+          <p className="mb-3 text-sm font-semibold text-holio-orange">
+            #general-updates
+          </p>
+          <p className="mb-4 text-[15px] leading-relaxed text-holio-text">
+            We just shipped the new AI agent dashboard — check out how it
+            simplifies your daily workflow and keeps the whole team in sync.
+          </p>
+
+          {/* Link preview */}
+          <a
+            href="#"
+            className="flex gap-3 rounded-xl border border-gray-100 bg-gray-50 p-3 transition-colors hover:bg-gray-100"
+          >
+            {samplePreview.image && (
+              <img
+                src={samplePreview.image}
+                alt=""
+                className="h-[72px] w-[72px] flex-shrink-0 rounded-lg object-cover"
+              />
+            )}
+            <div className="flex min-w-0 flex-1 flex-col justify-center">
+              <p className="truncate text-sm font-semibold text-holio-text">
+                {samplePreview.title}
+              </p>
+              <p className="mt-0.5 line-clamp-2 text-xs text-holio-muted">
+                {samplePreview.description}
+              </p>
+              <p className="mt-1 text-xs text-holio-muted">
+                {samplePreview.domain}
+              </p>
+            </div>
+          </a>
+        </div>
+      </div>
+
+      {/* Caption input */}
+      <div className="flex-shrink-0 px-4 pb-2">
+        <div className="flex items-center gap-3 rounded-full bg-white/10 px-4 py-2.5">
+          <input
+            type="text"
+            value={caption}
+            onChange={(e) => setCaption(e.target.value)}
+            placeholder="Add a caption..."
+            className="flex-1 bg-transparent text-sm text-white outline-none placeholder:text-white/50"
+          />
+          <Clock className="h-5 w-5 flex-shrink-0 text-white/50" />
+          <span className="text-xs text-white/50">24h</span>
+        </div>
+      </div>
+
+      {/* Bottom toolbar */}
+      <div className="flex flex-shrink-0 items-center justify-between px-4 pb-6 pt-2">
+        <div className="flex items-center gap-1">
+          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
+            <Paperclip className="h-5 w-5 text-white" />
+          </button>
+          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
+            <Smile className="h-5 w-5 text-white" />
+          </button>
+          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
+            <Type className="h-5 w-5 text-white" />
+          </button>
+          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
+            <SlidersHorizontal className="h-5 w-5 text-white" />
+          </button>
+        </div>
+
+        <button className="flex items-center gap-1.5 rounded-full bg-holio-orange px-6 py-2.5 text-sm font-bold text-white shadow-lg transition-colors hover:bg-holio-orange/90">
+          NEXT
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/StoryPage.tsx
+++ b/frontend/src/pages/StoryPage.tsx
@@ -1,126 +1,288 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import {
-  ArrowLeft,
-  Bookmark,
-  Paperclip,
-  Smile,
-  Type,
-  SlidersHorizontal,
-  ChevronRight,
-  Clock,
-} from 'lucide-react'
+import { useEffect, useState, useMemo } from 'react'
+import { Camera, Image, Plus, X, BookOpen } from 'lucide-react'
+import { useStoryStore } from '../stores/storyStore'
+import { useAuthStore } from '../stores/authStore'
+import StoryCircle from '../components/stories/StoryCircle'
+import StoryViewer from '../components/stories/StoryViewer'
+import Sidebar from '../components/layout/Sidebar'
+import BottomNavBar from '../components/layout/BottomNavBar'
+import type { StoryGroup } from '../types'
 
-interface LinkPreviewData {
-  title: string
-  description: string
-  domain: string
-  image?: string
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor(
+    (Date.now() - new Date(dateStr).getTime()) / 1000,
+  )
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
 }
 
 export default function StoryPage() {
-  const navigate = useNavigate()
-  const [caption, setCaption] = useState('')
+  const storyGroups = useStoryStore((s) => s.storyGroups)
+  const loading = useStoryStore((s) => s.loading)
+  const fetchStories = useStoryStore((s) => s.fetchStories)
+  const openViewer = useStoryStore((s) => s.openViewer)
+  const currentUser = useAuthStore((s) => s.user)
 
-  const samplePreview: LinkPreviewData = {
-    title: 'Understanding Modern AI Agents',
-    description:
-      'A deep dive into how AI agents are transforming enterprise workflows and team collaboration.',
-    domain: 'blog.holio.ai',
-    image: 'https://picsum.photos/seed/story/120/80',
+  const [showCreateMenu, setShowCreateMenu] = useState(false)
+
+  useEffect(() => {
+    fetchStories()
+  }, [fetchStories])
+
+  const myGroup = useMemo(
+    () => storyGroups.find((g) => g.user.id === currentUser?.id),
+    [storyGroups, currentUser?.id],
+  )
+
+  const otherGroups = useMemo(
+    () => storyGroups.filter((g) => g.user.id !== currentUser?.id),
+    [storyGroups, currentUser?.id],
+  )
+
+  const recentGroups = useMemo(
+    () => otherGroups.filter((g) => !g.stories.every((s) => s.viewed)),
+    [otherGroups],
+  )
+
+  const viewedGroups = useMemo(
+    () => otherGroups.filter((g) => g.stories.every((s) => s.viewed)),
+    [otherGroups],
+  )
+
+  const handleOpenGroup = (group: StoryGroup) => {
+    const idx = storyGroups.indexOf(group)
+    if (idx !== -1) openViewer(idx)
   }
 
+  const handleCreateOption = (_type: 'camera' | 'gallery') => {
+    setShowCreateMenu(false)
+  }
+
+  const hasNoStories = storyGroups.length === 0 && !loading
+
   return (
-    <div className="flex h-screen flex-col bg-holio-dark">
-      {/* Header */}
-      <header className="flex flex-shrink-0 items-center justify-between px-4 py-3">
-        <button
-          onClick={() => navigate(-1)}
-          className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10"
-        >
-          <ArrowLeft className="h-6 w-6 text-white" />
-        </button>
-        <h1 className="text-lg font-semibold text-white">New Story</h1>
-        <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
-          <Bookmark className="h-5 w-5 text-white" />
-        </button>
-      </header>
+    <div className="flex h-screen bg-holio-offwhite">
+      <Sidebar />
 
-      {/* Content area */}
-      <div className="flex flex-1 flex-col items-center justify-center px-4">
-        <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
-          <p className="mb-3 text-sm font-semibold text-holio-orange">
-            #general-updates
-          </p>
-          <p className="mb-4 text-[15px] leading-relaxed text-holio-text">
-            We just shipped the new AI agent dashboard — check out how it
-            simplifies your daily workflow and keeps the whole team in sync.
-          </p>
-
-          {/* Link preview */}
-          <a
-            href="#"
-            className="flex gap-3 rounded-xl border border-gray-100 bg-gray-50 p-3 transition-colors hover:bg-gray-100"
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
+          <h1 className="text-xl font-bold text-holio-dark">Stories</h1>
+          <button
+            onClick={() => setShowCreateMenu(true)}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-holio-dark transition-colors hover:bg-gray-100"
+            aria-label="Create story"
           >
-            {samplePreview.image && (
-              <img
-                src={samplePreview.image}
-                alt=""
-                className="h-[72px] w-[72px] flex-shrink-0 rounded-lg object-cover"
-              />
-            )}
-            <div className="flex min-w-0 flex-1 flex-col justify-center">
-              <p className="truncate text-sm font-semibold text-holio-text">
-                {samplePreview.title}
-              </p>
-              <p className="mt-0.5 line-clamp-2 text-xs text-holio-muted">
-                {samplePreview.description}
-              </p>
-              <p className="mt-1 text-xs text-holio-muted">
-                {samplePreview.domain}
-              </p>
+            <Camera className="h-5 w-5" />
+          </button>
+        </header>
+
+        <main className="flex-1 overflow-y-auto px-6 py-5">
+          {loading && storyGroups.length === 0 ? (
+            <div className="flex h-64 items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
             </div>
-          </a>
-        </div>
+          ) : hasNoStories ? (
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-holio-lavender/40">
+                <BookOpen className="h-8 w-8 text-holio-dark/60" />
+              </div>
+              <h2 className="mb-1 text-lg font-semibold text-holio-dark">
+                No stories yet
+              </h2>
+              <p className="mb-6 max-w-xs text-sm text-holio-muted">
+                Share photos and videos that disappear after 24 hours with your
+                team.
+              </p>
+              <button
+                onClick={() => setShowCreateMenu(true)}
+                className="flex items-center gap-2 rounded-full bg-holio-orange px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-orange-600"
+              >
+                <Plus className="h-4 w-4" />
+                Create your first story
+              </button>
+            </div>
+          ) : (
+            <>
+              <section className="mb-6">
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                  My Story
+                </h2>
+                {myGroup ? (
+                  <button
+                    onClick={() => handleOpenGroup(myGroup)}
+                    className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-white"
+                  >
+                    <StoryCircle
+                      group={myGroup}
+                      isOwn
+                      onClick={() => handleOpenGroup(myGroup)}
+                    />
+                    <div className="text-left">
+                      <p className="text-sm font-semibold text-holio-dark">
+                        My Story
+                      </p>
+                      <p className="text-xs text-holio-muted">
+                        {timeAgo(
+                          myGroup.stories[myGroup.stories.length - 1]
+                            .createdAt,
+                        )}
+                      </p>
+                    </div>
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => setShowCreateMenu(true)}
+                    className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-white"
+                  >
+                    <div className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-dashed border-holio-orange/40 bg-holio-orange/5">
+                      <Plus className="h-6 w-6 text-holio-orange" />
+                    </div>
+                    <div className="text-left">
+                      <p className="text-sm font-semibold text-holio-dark">
+                        Add Story
+                      </p>
+                      <p className="text-xs text-holio-muted">
+                        Share a photo or video
+                      </p>
+                    </div>
+                  </button>
+                )}
+              </section>
+
+              {recentGroups.length > 0 && (
+                <section className="mb-6">
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                    Recent
+                  </h2>
+                  <div className="space-y-1">
+                    {recentGroups.map((group) => (
+                      <StoryRow
+                        key={group.user.id}
+                        group={group}
+                        onClick={() => handleOpenGroup(group)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {viewedGroups.length > 0 && (
+                <section>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                    Viewed
+                  </h2>
+                  <div className="space-y-1 opacity-60">
+                    {viewedGroups.map((group) => (
+                      <StoryRow
+                        key={group.user.id}
+                        group={group}
+                        onClick={() => handleOpenGroup(group)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </main>
+
+        <BottomNavBar />
       </div>
 
-      {/* Caption input */}
-      <div className="flex-shrink-0 px-4 pb-2">
-        <div className="flex items-center gap-3 rounded-full bg-white/10 px-4 py-2.5">
-          <input
-            type="text"
-            value={caption}
-            onChange={(e) => setCaption(e.target.value)}
-            placeholder="Add a caption..."
-            className="flex-1 bg-transparent text-sm text-white outline-none placeholder:text-white/50"
-          />
-          <Clock className="h-5 w-5 flex-shrink-0 text-white/50" />
-          <span className="text-xs text-white/50">24h</span>
+      {showCreateMenu && (
+        <div
+          className="fixed inset-0 z-40 flex items-end justify-center bg-black/40 sm:items-center"
+          onClick={() => setShowCreateMenu(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-t-2xl bg-white p-6 sm:rounded-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-base font-semibold text-holio-dark">
+                Create Story
+              </h3>
+              <button
+                onClick={() => setShowCreateMenu(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-100"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="space-y-1">
+              <button
+                onClick={() => handleCreateOption('camera')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-holio-offwhite"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-orange/10">
+                  <Camera className="h-5 w-5 text-holio-orange" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-holio-dark">
+                    Take Photo
+                  </p>
+                  <p className="text-xs text-holio-muted">
+                    Use your camera to capture a moment
+                  </p>
+                </div>
+              </button>
+              <button
+                onClick={() => handleCreateOption('gallery')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-holio-offwhite"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-lavender/30">
+                  <Image className="h-5 w-5 text-holio-dark/70" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-holio-dark">
+                    Choose from Gallery
+                  </p>
+                  <p className="text-xs text-holio-muted">
+                    Pick an existing photo or video
+                  </p>
+                </div>
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
 
-      {/* Bottom toolbar */}
-      <div className="flex flex-shrink-0 items-center justify-between px-4 pb-6 pt-2">
-        <div className="flex items-center gap-1">
-          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
-            <Paperclip className="h-5 w-5 text-white" />
-          </button>
-          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
-            <Smile className="h-5 w-5 text-white" />
-          </button>
-          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
-            <Type className="h-5 w-5 text-white" />
-          </button>
-          <button className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/10">
-            <SlidersHorizontal className="h-5 w-5 text-white" />
-          </button>
-        </div>
-
-        <button className="flex items-center gap-1.5 rounded-full bg-holio-orange px-6 py-2.5 text-sm font-bold text-white shadow-lg transition-colors hover:bg-holio-orange/90">
-          NEXT
-          <ChevronRight className="h-4 w-4" />
-        </button>
-      </div>
+      <StoryViewer />
     </div>
+  )
+}
+
+function StoryRow({
+  group,
+  onClick,
+}: {
+  group: StoryGroup
+  onClick: () => void
+}) {
+  const latestStory = group.stories[group.stories.length - 1]
+  const unviewedCount = group.stories.filter((s) => !s.viewed).length
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors hover:bg-white"
+    >
+      <StoryCircle group={group} onClick={onClick} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-holio-dark">
+          {group.user.firstName ?? group.user.username}
+        </p>
+        <p className="text-xs text-holio-muted">{timeAgo(latestStory.createdAt)}</p>
+      </div>
+      {unviewedCount > 0 && (
+        <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-holio-orange px-1.5 text-[11px] font-semibold text-white">
+          {unviewedCount}
+        </span>
+      )}
+    </button>
   )
 }


### PR DESCRIPTION
## Summary
- Replaces StoryPage placeholder with full story listing and viewer UI
- Adds My Story section with create button (when no story exists) or own story preview with time-ago timestamp
- Adds Recent stories section (unviewed groups) and Viewed section (grayed out, 60% opacity)
- Includes empty state with CTA to create first story
- Create story bottom-sheet modal with Take Photo and Choose from Gallery options
- Integrates full-screen StoryViewer component for viewing stories
- Uses storyStore for data fetching and viewer state management

## Changes
- `frontend/src/pages/StoryPage.tsx` — full rewrite with story listing UI, create menu, viewer integration

## Test plan
- [ ] Navigate to `/stories` route — page renders with correct layout
- [ ] Verify empty state shows when no stories exist with CTA button
- [ ] Verify My Story section shows create button when user has no story
- [ ] Verify My Story section shows preview when user has a story
- [ ] Verify Recent section lists unviewed story groups with unviewed badge count
- [ ] Verify Viewed section lists fully viewed groups with reduced opacity
- [ ] Click camera icon or CTA — create story menu appears
- [ ] Click story circle — full-screen StoryViewer opens
- [ ] Verify time-ago formatting displays correctly (just now, Xm ago, Xh ago, Xd ago)

Closes #132
