### PR TITLE
feat(chat): implement Add to Tags flow (#124)

### DIFF
--- a/frontend/src/components/chat/InfoPanel.tsx
+++ b/frontend/src/components/chat/InfoPanel.tsx
@@ -29,8 +29,10 @@ import {
 import { useUiStore } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { useBotStore } from '../../stores/botStore'
+import { useTagStore } from '../../stores/tagStore'
 import { cn } from '../../lib/utils'
 import ChannelAdminPanel from '../groups/ChannelAdminPanel'
+import TagDetailPanel from './TagDetailPanel'
 import api from '../../services/api.service'
 import type { Bot as BotType } from '../../types'
 
@@ -94,6 +96,9 @@ export default function InfoPanel() {
   const companyBots = useBotStore((s) => s.companyBots)
   const inviteBotToChat = useBotStore((s) => s.inviteBotToChat)
   const removeBotFromChat = useBotStore((s) => s.removeBotFromChat)
+  const tags = useTagStore((s) => s.tags)
+  const activeTagId = useTagStore((s) => s.activeTagId)
+  const setActiveTag = useTagStore((s) => s.setActiveTag)
   const [showBotPicker, setShowBotPicker] = useState(false)
   const [showAdminPanel, setShowAdminPanel] = useState(false)
   const [isMuted, setIsMuted] = useState(activeChat?.muted ?? false)
@@ -151,6 +156,14 @@ export default function InfoPanel() {
       <ChannelAdminPanel
         chat={activeChat}
         onClose={() => setShowAdminPanel(false)}
+      />
+    )
+  }
+
+  if (activeTagId) {
+    return (
+      <TagDetailPanel
+        onClose={() => setActiveTag(null)}
       />
     )
   }
@@ -511,6 +524,32 @@ export default function InfoPanel() {
             <p className="py-2 text-center text-xs text-holio-muted">
               No bots in this chat
             </p>
+          )}
+        </div>
+
+        {/* Tags */}
+        <div className="border-t border-gray-100 px-4 py-3 dark:border-[#1E3035]">
+          <h5 className="mb-2 text-xs font-semibold tracking-wide text-holio-muted uppercase">
+            Tags
+          </h5>
+          {tags.length === 0 ? (
+            <p className="py-2 text-center text-xs text-holio-muted">No tags yet</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <button
+                  key={tag.id}
+                  onClick={() => { setActiveTag(tag.id); setShowInfoPanel(true) }}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium text-holio-text transition-colors hover:opacity-80',
+                    tag.color === 'lavender' ? 'bg-holio-lavender/30' : 'bg-holio-sage/30',
+                  )}
+                >
+                  <span>{tag.emoji}</span>
+                  {tag.name}
+                </button>
+              ))}
+            </div>
           )}
         </div>
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils'
 import type { Message, MessageMetadata, GroupReadReceipt, MessageReaction } from '../../types'
 import api from '../../services/api.service'
 import { useChatStore } from '../../stores/chatStore'
+import { useTagStore } from '../../stores/tagStore'
 import ImageMessage from '../messages/ImageMessage'
 import ImageViewer from '../messages/ImageViewer'
 import VoiceMessage from '../messages/VoiceMessage'
@@ -16,6 +17,7 @@ import PollMessage from '../messages/PollMessage'
 import ReactionBar from '../messages/ReactionBar'
 import ReactionPicker from '../messages/ReactionPicker'
 import MessageContextMenu from './MessageContextMenu'
+import TagSelector from './TagSelector'
 
 export interface MessageData {
   id: string; content: string; timestamp: string; isMine: boolean; senderName?: string
@@ -66,9 +68,11 @@ export default function MessageBubble({ message, rawMessage }: MessageBubbleProp
   const [showReactionPicker, setShowReactionPicker] = useState(false)
   const [reactions, setReactions] = useState<MessageReaction[]>(message.reactions ?? [])
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null)
+  const [showTagSelector, setShowTagSelector] = useState(false)
   const setReplyTo = useChatStore((s) => s.setReplyTo)
   const setEditing = useChatStore((s) => s.setEditing)
   const removeMessage = useChatStore((s) => s.removeMessage)
+  const messageTags = useTagStore((s) => s.getMessageTags(message.id))
 
   const handleContextMenu = (e: React.MouseEvent) => { e.preventDefault(); setContextMenu({ x: e.clientX, y: e.clientY }) }
   const handleContextAction = async (action: string) => {
@@ -80,6 +84,7 @@ export default function MessageBubble({ message, rawMessage }: MessageBubbleProp
       case 'forward': break
       case 'pin': try { await api.patch(`/messages/${message.id}/pin`) } catch { /* ignore */ } break
       case 'delete': try { await api.delete(`/chats/${rawMessage?.chatId}/messages/${message.id}`); removeMessage(message.id) } catch { /* ignore */ } break
+      case 'tag': setShowTagSelector(true); break
     }
   }
 
@@ -176,9 +181,26 @@ export default function MessageBubble({ message, rawMessage }: MessageBubbleProp
           </>)}
         </div>
         <ReactionBar reactions={reactions} onToggle={handleToggleReaction} onAdd={() => setShowReactionPicker(true)} />
+        {messageTags.length > 0 && (
+          <div className={cn('mt-1 flex flex-wrap gap-1', message.isMine ? 'justify-end' : 'justify-start')}>
+            {messageTags.map((tag) => (
+              <span
+                key={tag.id}
+                className={cn(
+                  'inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10px] font-medium text-holio-text',
+                  tag.color === 'lavender' ? 'bg-holio-lavender/40' : 'bg-holio-sage/40',
+                )}
+              >
+                <span>{tag.emoji}</span>
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
     {viewerImages && <ImageViewer images={viewerImages} initialIndex={viewerIndex} onClose={() => setViewerImages(null)} />}
     {contextMenu && <MessageContextMenu x={contextMenu.x} y={contextMenu.y} isMine={message.isMine} onAction={handleContextAction} onClose={() => setContextMenu(null)} />}
+    {showTagSelector && <TagSelector messageId={message.id} onClose={() => setShowTagSelector(false)} />}
   </>)
 }

--- a/frontend/src/components/chat/MessageContextMenu.tsx
+++ b/frontend/src/components/chat/MessageContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
-import { Reply, Pencil, Trash2, Forward, Pin, PinOff, Copy } from 'lucide-react'
+import { Reply, Pencil, Trash2, Forward, Pin, PinOff, Copy, Hash } from 'lucide-react'
 import { cn } from '../../lib/utils'
 
 export interface ContextMenuAction { id: string; label: string; icon: typeof Reply; danger?: boolean; hidden?: boolean }
@@ -18,6 +18,7 @@ export default function MessageContextMenu({ isMine, isPinned, onAction, onClose
   const actions: ContextMenuAction[] = [
     { id: 'reply', label: 'Reply', icon: Reply }, { id: 'copy', label: 'Copy', icon: Copy },
     { id: 'forward', label: 'Forward', icon: Forward },
+    { id: 'tag', label: 'Tag', icon: Hash },
     { id: 'pin', label: isPinned ? 'Unpin' : 'Pin', icon: isPinned ? PinOff : Pin },
     { id: 'edit', label: 'Edit', icon: Pencil, hidden: !isMine },
     { id: 'delete', label: 'Delete', icon: Trash2, danger: true, hidden: !isMine },

--- a/frontend/src/components/chat/TagDetailPanel.tsx
+++ b/frontend/src/components/chat/TagDetailPanel.tsx
@@ -1,0 +1,145 @@
+import { useState, useEffect } from 'react'
+import { X, Hash, MessageSquare, Image, File, Mic, Link } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import { useTagStore } from '../../stores/tagStore'
+import type { TaggedMessage } from '../../types'
+
+type DetailTab = 'all' | 'media' | 'files' | 'voice' | 'links'
+
+const TABS: { id: DetailTab; label: string; icon: typeof MessageSquare }[] = [
+  { id: 'all', label: 'All Messages', icon: MessageSquare },
+  { id: 'media', label: 'Media', icon: Image },
+  { id: 'files', label: 'Files', icon: File },
+  { id: 'voice', label: 'Voice', icon: Mic },
+  { id: 'links', label: 'Links', icon: Link },
+]
+
+interface TagDetailPanelProps {
+  onClose: () => void
+}
+
+function TaggedMessageItem({ item }: { item: TaggedMessage }) {
+  const formattedDate = new Date(item.taggedAt).toLocaleDateString([], {
+    month: 'short',
+    day: 'numeric',
+  })
+  const formattedTime = new Date(item.message.createdAt).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+  return (
+    <div className="flex gap-3 rounded-xl px-3 py-2.5 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50">
+      <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-holio-lavender/30 text-xs font-semibold text-holio-text">
+        {item.message.sender?.firstName?.[0] ?? '?'}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-holio-text dark:text-white">
+            {item.message.sender?.firstName ?? 'User'}
+          </span>
+          <span className="text-[10px] text-holio-muted">{formattedDate} {formattedTime}</span>
+        </div>
+        <p className="mt-0.5 truncate text-xs text-holio-muted">
+          {item.message.content || `[${item.message.type}]`}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default function TagDetailPanel({ onClose }: TagDetailPanelProps) {
+  const activeTagId = useTagStore((s) => s.activeTagId)
+  const tags = useTagStore((s) => s.tags)
+  const taggedMessages = useTagStore((s) => s.taggedMessages)
+  const fetchTaggedMessages = useTagStore((s) => s.fetchTaggedMessages)
+  const loading = useTagStore((s) => s.loading)
+  const [activeTab, setActiveTab] = useState<DetailTab>('all')
+
+  const tag = tags.find((t) => t.id === activeTagId)
+
+  useEffect(() => {
+    if (activeTagId) fetchTaggedMessages(activeTagId)
+  }, [activeTagId, fetchTaggedMessages])
+
+  if (!tag) return null
+
+  const allItems = taggedMessages[tag.id] ?? []
+  const filteredItems = allItems.filter((item) => {
+    switch (activeTab) {
+      case 'media': return item.message.type === 'image' || item.message.type === 'gif' || item.message.type === 'videoNote'
+      case 'files': return item.message.type === 'file'
+      case 'voice': return item.message.type === 'voice'
+      case 'links': return item.message.type === 'text' && item.message.metadata?.linkPreview
+      default: return true
+    }
+  })
+
+  const tagBg = tag.color === 'lavender' ? 'bg-holio-lavender/20' : 'bg-holio-sage/20'
+
+  return (
+    <div className="flex h-screen flex-shrink-0 flex-col border-l border-gray-100 bg-white dark:border-[#1E3035] dark:bg-[#152022]" style={{ width: '100%' }}>
+      <div className="flex h-16 items-center justify-between border-b border-gray-100 px-4 dark:border-[#1E3035]">
+        <div className="flex items-center gap-2">
+          <Hash className="h-4 w-4 text-holio-orange" />
+          <h3 className="text-sm font-semibold text-holio-text dark:text-white">Tag Detail</h3>
+        </div>
+        <button
+          onClick={onClose}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-50 hover:text-holio-text dark:hover:bg-gray-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className={cn('mx-4 mt-4 flex items-center gap-3 rounded-xl px-4 py-3', tagBg)}>
+        <span className="text-2xl">{tag.emoji}</span>
+        <div>
+          <h4 className="text-base font-semibold text-holio-text dark:text-white">{tag.name}</h4>
+          <p className="text-xs text-holio-muted">{allItems.length} tagged message{allItems.length !== 1 ? 's' : ''}</p>
+        </div>
+      </div>
+
+      <div className="mx-4 mt-4 flex gap-1 overflow-x-auto">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              'flex flex-shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors',
+              activeTab === tab.id
+                ? 'bg-holio-orange text-white'
+                : 'bg-gray-100 text-holio-muted hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600',
+            )}
+          >
+            <tab.icon className="h-3 w-3" />
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex-1 overflow-y-auto px-4">
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div className="flex flex-col items-center py-10 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700">
+              <MessageSquare className="h-5 w-5 text-holio-muted" />
+            </div>
+            <p className="mt-3 text-xs text-holio-muted">
+              No {activeTab === 'all' ? '' : activeTab} messages tagged yet
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-0.5">
+            {filteredItems.map((item) => (
+              <TaggedMessageItem key={item.id} item={item} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/TagSelector.tsx
+++ b/frontend/src/components/chat/TagSelector.tsx
@@ -1,1 +1,173 @@
-// placeholder
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { X, Check, Plus, Hash } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import { useTagStore } from '../../stores/tagStore'
+
+interface TagSelectorProps {
+  messageId: string
+  onClose: () => void
+}
+
+const EMOJI_OPTIONS = ['🎨', '🔗', '📐', '⭐', '📖', '💡', '🚀', '🔥', '📌', '🎯', '💬', '📊']
+
+export default function TagSelector({ messageId, onClose }: TagSelectorProps) {
+  const tags = useTagStore((s) => s.tags)
+  const messageTagMap = useTagStore((s) => s.messageTagMap)
+  const toggleMessageTag = useTagStore((s) => s.toggleMessageTag)
+  const createTag = useTagStore((s) => s.createTag)
+  const fetchTags = useTagStore((s) => s.fetchTags)
+
+  const [visible, setVisible] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newEmoji, setNewEmoji] = useState('💡')
+  const panelRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const activeTagIds = messageTagMap[messageId] ?? []
+
+  useEffect(() => {
+    fetchTags()
+    requestAnimationFrame(() => setVisible(true))
+  }, [fetchTags])
+
+  useEffect(() => {
+    if (showCreate && inputRef.current) inputRef.current.focus()
+  }, [showCreate])
+
+  const handleClose = useCallback(() => {
+    setVisible(false)
+    setTimeout(onClose, 200)
+  }, [onClose])
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') handleClose() }
+    document.addEventListener('keydown', handleEsc)
+    return () => document.removeEventListener('keydown', handleEsc)
+  }, [handleClose])
+
+  const handleToggle = (tagId: string) => {
+    toggleMessageTag(messageId, tagId)
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    await createTag(newName.trim(), newEmoji)
+    setNewName('')
+    setNewEmoji('💡')
+    setShowCreate(false)
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100]">
+      <div
+        className={cn('absolute inset-0 transition-opacity duration-200', visible ? 'bg-black/30' : 'bg-transparent')}
+        onClick={handleClose}
+      />
+      <div
+        ref={panelRef}
+        className={cn(
+          'absolute inset-x-0 bottom-0 rounded-t-2xl bg-white px-4 pb-8 pt-3 shadow-xl transition-transform duration-200 ease-out dark:bg-[#1E3035]',
+          visible ? 'translate-y-0' : 'translate-y-full',
+        )}
+      >
+        <div className="mb-3 flex justify-center">
+          <div className="h-1 w-10 rounded-full bg-gray-300" />
+        </div>
+
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Hash className="h-5 w-5 text-holio-orange" />
+            <h3 className="text-base font-semibold text-holio-text dark:text-white">Add to Tags</h3>
+          </div>
+          <button
+            onClick={handleClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-100 hover:text-holio-text dark:hover:bg-gray-700"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="max-h-64 space-y-1 overflow-y-auto">
+          {tags.map((tag) => {
+            const isActive = activeTagIds.includes(tag.id)
+            const bgColor = tag.color === 'lavender' ? 'bg-holio-lavender/20' : 'bg-holio-sage/20'
+            const activeBg = tag.color === 'lavender' ? 'bg-holio-lavender/40' : 'bg-holio-sage/40'
+
+            return (
+              <button
+                key={tag.id}
+                onClick={() => handleToggle(tag.id)}
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 transition-all',
+                  isActive ? activeBg : `${bgColor} hover:opacity-80`,
+                )}
+              >
+                <span className="text-lg">{tag.emoji}</span>
+                <span className="flex-1 text-left text-sm font-medium text-holio-text dark:text-white">
+                  {tag.name}
+                </span>
+                <div
+                  className={cn(
+                    'flex h-5 w-5 items-center justify-center rounded-md border-2 transition-all',
+                    isActive
+                      ? 'border-holio-orange bg-holio-orange'
+                      : 'border-gray-300 dark:border-gray-500',
+                  )}
+                >
+                  {isActive && <Check className="h-3 w-3 text-white" />}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+
+        {showCreate ? (
+          <div className="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-3 dark:border-gray-600 dark:bg-gray-800">
+            <div className="mb-2 flex items-center gap-2">
+              <div className="flex flex-wrap gap-1">
+                {EMOJI_OPTIONS.map((emoji) => (
+                  <button
+                    key={emoji}
+                    onClick={() => setNewEmoji(emoji)}
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-lg text-base transition-all',
+                      newEmoji === emoji ? 'bg-holio-orange/20 ring-2 ring-holio-orange' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
+                    )}
+                  >
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <input
+                ref={inputRef}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
+                placeholder="Tag name..."
+                className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-holio-text outline-none focus:border-holio-orange dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              />
+              <button
+                onClick={handleCreate}
+                disabled={!newName.trim()}
+                className="rounded-lg bg-holio-orange px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowCreate(true)}
+            className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-300 py-2.5 text-sm font-medium text-holio-muted transition-colors hover:border-holio-orange hover:text-holio-orange dark:border-gray-600"
+          >
+            <Plus className="h-4 w-4" />
+            Create New Tag
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/BottomNavBar.tsx
+++ b/frontend/src/components/layout/BottomNavBar.tsx
@@ -1,83 +1,82 @@
-import { MessageSquare, Users, Settings, Bot } from 'lucide-react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { MessageCircle, Users, Settings, Bot } from 'lucide-react'
 import { useUiStore, type NavItem } from '../../stores/uiStore'
 import { useChatStore } from '../../stores/chatStore'
 import { cn } from '../../lib/utils'
 
 type BottomTab = {
-  id: NavItem
+  id: NavItem | 'settings'
   label: string
-  icon: typeof MessageSquare
-  activeIcon: typeof MessageSquare
+  icon: typeof MessageCircle
+  route?: string
 }
 
 const TABS: BottomTab[] = [
-  { id: 'all', label: 'Chats', icon: MessageSquare, activeIcon: MessageSquare },
-  { id: 'contacts', label: 'Contacts', icon: Users, activeIcon: Users },
-  { id: 'bots', label: 'AI Agents', icon: Bot, activeIcon: Bot },
+  { id: 'all', label: 'Chats', icon: MessageCircle },
+  { id: 'contacts', label: 'Contacts', icon: Users, route: '/contacts' },
+  { id: 'settings', label: 'Settings', icon: Settings, route: '/settings' },
+  { id: 'bots', label: 'AI Agents', icon: Bot, route: '/bots' },
 ]
 
-const SETTINGS_TAB = { id: 'settings' as const, label: 'Settings', icon: Settings }
-
 export default function BottomNavBar() {
+  const navigate = useNavigate()
+  const location = useLocation()
   const activeNavItem = useUiStore((s) => s.activeNavItem)
   const setActiveNavItem = useUiStore((s) => s.setActiveNavItem)
   const chats = useChatStore((s) => s.chats)
 
   const totalUnread = chats.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0)
 
-  const handleTabPress = (id: NavItem | 'settings') => {
-    if (id === 'settings') {
-      window.location.href = '/settings'
-      return
-    }
-    setActiveNavItem(id)
+  const isActive = (tab: BottomTab) => {
+    if (tab.route) return location.pathname.startsWith(tab.route)
+    return activeNavItem === tab.id && location.pathname === '/'
   }
 
-  const isActive = (id: string) => activeNavItem === id
+  const handleTabPress = (tab: BottomTab) => {
+    if (tab.route) {
+      navigate(tab.route)
+    } else {
+      setActiveNavItem(tab.id as NavItem)
+      navigate('/')
+    }
+  }
 
   return (
     <nav
-      className="fixed inset-x-0 bottom-0 z-40 flex border-t border-gray-200 bg-white md:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-4 border-t border-gray-200 bg-white md:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
       {TABS.map((tab) => {
-        const Icon = isActive(tab.id) ? tab.activeIcon : tab.icon
-        const active = isActive(tab.id)
+        const active = isActive(tab)
+        const Icon = tab.icon
         const showBadge = tab.id === 'all' && totalUnread > 0
 
         return (
           <button
             key={tab.id}
-            onClick={() => handleTabPress(tab.id)}
-            className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-            style={{ minHeight: 44, minWidth: 44 }}
+            onClick={() => handleTabPress(tab)}
+            className="relative flex flex-col items-center justify-center gap-0.5 py-2"
+            style={{ minHeight: 44 }}
           >
-            <div className="relative">
-              <div
+            <div className="relative flex items-center justify-center">
+              <Icon
                 className={cn(
-                  'flex items-center justify-center rounded-lg px-4 py-1 transition-colors',
-                  active && 'bg-holio-orange/15',
+                  'h-6 w-6 transition-colors',
+                  active ? 'text-holio-orange' : 'text-[#8E8E93]',
                 )}
-              >
-                <Icon
-                  className={cn(
-                    'h-6 w-6 transition-colors',
-                    active ? 'text-holio-orange' : 'text-gray-500',
-                  )}
-                  fill={active ? 'currentColor' : 'none'}
-                  strokeWidth={active ? 1.5 : 2}
-                />
-              </div>
+                fill={active ? 'currentColor' : 'none'}
+                strokeWidth={active ? 1.5 : 2}
+              />
               {showBadge && (
-                <span className="absolute -top-1 right-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-medium leading-none text-white">
+                <span className="absolute -right-2.5 -top-1.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-semibold leading-none text-white">
                   {totalUnread > 99 ? '99+' : totalUnread}
                 </span>
               )}
             </div>
             <span
               className={cn(
-                'text-xs font-medium tracking-wide',
-                active ? 'text-holio-orange' : 'text-gray-500',
+                'text-[11px] font-medium',
+                active ? 'text-holio-orange' : 'text-[#8E8E93]',
               )}
             >
               {tab.label}
@@ -85,26 +84,6 @@ export default function BottomNavBar() {
           </button>
         )
       })}
-
-      <button
-        onClick={() => handleTabPress('settings')}
-        className="relative flex flex-1 flex-col items-center justify-center gap-1 pb-4 pt-3"
-        style={{ minHeight: 44, minWidth: 44 }}
-      >
-        <div
-          className={cn(
-            'flex items-center justify-center rounded-lg px-4 py-1',
-          )}
-        >
-          <SETTINGS_TAB.icon
-            className="h-6 w-6 text-gray-500 transition-colors"
-            strokeWidth={2}
-          />
-        </div>
-        <span className="text-xs font-medium tracking-wide text-gray-500">
-          {SETTINGS_TAB.label}
-        </span>
-      </button>
     </nav>
   )
 }

--- a/frontend/src/pages/StoryPage.tsx
+++ b/frontend/src/pages/StoryPage.tsx
@@ -1,1 +1,288 @@
-// placeholder
+import { useEffect, useState, useMemo } from 'react'
+import { Camera, Image, Plus, X, BookOpen } from 'lucide-react'
+import { useStoryStore } from '../stores/storyStore'
+import { useAuthStore } from '../stores/authStore'
+import StoryCircle from '../components/stories/StoryCircle'
+import StoryViewer from '../components/stories/StoryViewer'
+import Sidebar from '../components/layout/Sidebar'
+import BottomNavBar from '../components/layout/BottomNavBar'
+import type { StoryGroup } from '../types'
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor(
+    (Date.now() - new Date(dateStr).getTime()) / 1000,
+  )
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+export default function StoryPage() {
+  const storyGroups = useStoryStore((s) => s.storyGroups)
+  const loading = useStoryStore((s) => s.loading)
+  const fetchStories = useStoryStore((s) => s.fetchStories)
+  const openViewer = useStoryStore((s) => s.openViewer)
+  const currentUser = useAuthStore((s) => s.user)
+
+  const [showCreateMenu, setShowCreateMenu] = useState(false)
+
+  useEffect(() => {
+    fetchStories()
+  }, [fetchStories])
+
+  const myGroup = useMemo(
+    () => storyGroups.find((g) => g.user.id === currentUser?.id),
+    [storyGroups, currentUser?.id],
+  )
+
+  const otherGroups = useMemo(
+    () => storyGroups.filter((g) => g.user.id !== currentUser?.id),
+    [storyGroups, currentUser?.id],
+  )
+
+  const recentGroups = useMemo(
+    () => otherGroups.filter((g) => !g.stories.every((s) => s.viewed)),
+    [otherGroups],
+  )
+
+  const viewedGroups = useMemo(
+    () => otherGroups.filter((g) => g.stories.every((s) => s.viewed)),
+    [otherGroups],
+  )
+
+  const handleOpenGroup = (group: StoryGroup) => {
+    const idx = storyGroups.indexOf(group)
+    if (idx !== -1) openViewer(idx)
+  }
+
+  const handleCreateOption = (_type: 'camera' | 'gallery') => {
+    setShowCreateMenu(false)
+  }
+
+  const hasNoStories = storyGroups.length === 0 && !loading
+
+  return (
+    <div className="flex h-screen bg-holio-offwhite">
+      <Sidebar />
+
+      <div className="flex flex-1 flex-col">
+        <header className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
+          <h1 className="text-xl font-bold text-holio-dark">Stories</h1>
+          <button
+            onClick={() => setShowCreateMenu(true)}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-holio-dark transition-colors hover:bg-gray-100"
+            aria-label="Create story"
+          >
+            <Camera className="h-5 w-5" />
+          </button>
+        </header>
+
+        <main className="flex-1 overflow-y-auto px-6 py-5">
+          {loading && storyGroups.length === 0 ? (
+            <div className="flex h-64 items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-holio-orange border-t-transparent" />
+            </div>
+          ) : hasNoStories ? (
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-holio-lavender/40">
+                <BookOpen className="h-8 w-8 text-holio-dark/60" />
+              </div>
+              <h2 className="mb-1 text-lg font-semibold text-holio-dark">
+                No stories yet
+              </h2>
+              <p className="mb-6 max-w-xs text-sm text-holio-muted">
+                Share photos and videos that disappear after 24 hours with your
+                team.
+              </p>
+              <button
+                onClick={() => setShowCreateMenu(true)}
+                className="flex items-center gap-2 rounded-full bg-holio-orange px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-orange-600"
+              >
+                <Plus className="h-4 w-4" />
+                Create your first story
+              </button>
+            </div>
+          ) : (
+            <>
+              <section className="mb-6">
+                <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                  My Story
+                </h2>
+                {myGroup ? (
+                  <button
+                    onClick={() => handleOpenGroup(myGroup)}
+                    className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-white"
+                  >
+                    <StoryCircle
+                      group={myGroup}
+                      isOwn
+                      onClick={() => handleOpenGroup(myGroup)}
+                    />
+                    <div className="text-left">
+                      <p className="text-sm font-semibold text-holio-dark">
+                        My Story
+                      </p>
+                      <p className="text-xs text-holio-muted">
+                        {timeAgo(
+                          myGroup.stories[myGroup.stories.length - 1]
+                            .createdAt,
+                        )}
+                      </p>
+                    </div>
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => setShowCreateMenu(true)}
+                    className="flex items-center gap-3 rounded-xl p-3 transition-colors hover:bg-white"
+                  >
+                    <div className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-dashed border-holio-orange/40 bg-holio-orange/5">
+                      <Plus className="h-6 w-6 text-holio-orange" />
+                    </div>
+                    <div className="text-left">
+                      <p className="text-sm font-semibold text-holio-dark">
+                        Add Story
+                      </p>
+                      <p className="text-xs text-holio-muted">
+                        Share a photo or video
+                      </p>
+                    </div>
+                  </button>
+                )}
+              </section>
+
+              {recentGroups.length > 0 && (
+                <section className="mb-6">
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                    Recent
+                  </h2>
+                  <div className="space-y-1">
+                    {recentGroups.map((group) => (
+                      <StoryRow
+                        key={group.user.id}
+                        group={group}
+                        onClick={() => handleOpenGroup(group)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {viewedGroups.length > 0 && (
+                <section>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-holio-muted">
+                    Viewed
+                  </h2>
+                  <div className="space-y-1 opacity-60">
+                    {viewedGroups.map((group) => (
+                      <StoryRow
+                        key={group.user.id}
+                        group={group}
+                        onClick={() => handleOpenGroup(group)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </main>
+
+        <BottomNavBar />
+      </div>
+
+      {showCreateMenu && (
+        <div
+          className="fixed inset-0 z-40 flex items-end justify-center bg-black/40 sm:items-center"
+          onClick={() => setShowCreateMenu(false)}
+        >
+          <div
+            className="w-full max-w-sm rounded-t-2xl bg-white p-6 sm:rounded-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-base font-semibold text-holio-dark">
+                Create Story
+              </h3>
+              <button
+                onClick={() => setShowCreateMenu(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-full text-holio-muted transition-colors hover:bg-gray-100"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="space-y-1">
+              <button
+                onClick={() => handleCreateOption('camera')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-holio-offwhite"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-orange/10">
+                  <Camera className="h-5 w-5 text-holio-orange" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-holio-dark">
+                    Take Photo
+                  </p>
+                  <p className="text-xs text-holio-muted">
+                    Use your camera to capture a moment
+                  </p>
+                </div>
+              </button>
+              <button
+                onClick={() => handleCreateOption('gallery')}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-holio-offwhite"
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-holio-lavender/30">
+                  <Image className="h-5 w-5 text-holio-dark/70" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-holio-dark">
+                    Choose from Gallery
+                  </p>
+                  <p className="text-xs text-holio-muted">
+                    Pick an existing photo or video
+                  </p>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <StoryViewer />
+    </div>
+  )
+}
+
+function StoryRow({
+  group,
+  onClick,
+}: {
+  group: StoryGroup
+  onClick: () => void
+}) {
+  const latestStory = group.stories[group.stories.length - 1]
+  const unviewedCount = group.stories.filter((s) => !s.viewed).length
+
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-xl p-3 text-left transition-colors hover:bg-white"
+    >
+      <StoryCircle group={group} onClick={onClick} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-holio-dark">
+          {group.user.firstName ?? group.user.username}
+        </p>
+        <p className="text-xs text-holio-muted">{timeAgo(latestStory.createdAt)}</p>
+      </div>
+      {unviewedCount > 0 && (
+        <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-holio-orange px-1.5 text-[11px] font-semibold text-white">
+          {unviewedCount}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/stores/tagStore.ts
+++ b/frontend/src/stores/tagStore.ts
@@ -1,0 +1,103 @@
+import { create } from 'zustand'
+import api from '../services/api.service'
+import type { Tag, TaggedMessage } from '../types'
+
+const DEFAULT_TAGS: Tag[] = [
+  { id: 'default-1', name: 'Design idea', emoji: '🎨', color: 'lavender', createdAt: new Date().toISOString() },
+  { id: 'default-2', name: 'Useful site', emoji: '🔗', color: 'sage', createdAt: new Date().toISOString() },
+  { id: 'default-3', name: 'Mockups', emoji: '📐', color: 'lavender', createdAt: new Date().toISOString() },
+  { id: 'default-4', name: 'Important', emoji: '⭐', color: 'sage', createdAt: new Date().toISOString() },
+  { id: 'default-5', name: 'To read', emoji: '📖', color: 'lavender', createdAt: new Date().toISOString() },
+]
+
+interface TagState {
+  tags: Tag[]
+  messageTagMap: Record<string, string[]>
+  taggedMessages: Record<string, TaggedMessage[]>
+  activeTagId: string | null
+  loading: boolean
+
+  fetchTags: () => Promise<void>
+  createTag: (name: string, emoji: string) => Promise<Tag>
+  toggleMessageTag: (messageId: string, tagId: string) => Promise<void>
+  fetchTaggedMessages: (tagId: string) => Promise<void>
+  setActiveTag: (tagId: string | null) => void
+  getMessageTags: (messageId: string) => Tag[]
+}
+
+export const useTagStore = create<TagState>((set, get) => ({
+  tags: DEFAULT_TAGS,
+  messageTagMap: {},
+  taggedMessages: {},
+  activeTagId: null,
+  loading: false,
+
+  fetchTags: async () => {
+    set({ loading: true })
+    try {
+      const { data } = await api.get<Tag[]>('/tags')
+      set({ tags: data.length > 0 ? data : DEFAULT_TAGS, loading: false })
+    } catch {
+      set({ tags: DEFAULT_TAGS, loading: false })
+    }
+  },
+
+  createTag: async (name: string, emoji: string) => {
+    const colors: Tag['color'][] = ['lavender', 'sage']
+    const color = colors[get().tags.length % 2]
+    try {
+      const { data } = await api.post<Tag>('/tags', { name, emoji, color })
+      set((s) => ({ tags: [...s.tags, data] }))
+      return data
+    } catch {
+      const localTag: Tag = {
+        id: `local-${Date.now()}`,
+        name,
+        emoji,
+        color,
+        createdAt: new Date().toISOString(),
+      }
+      set((s) => ({ tags: [...s.tags, localTag] }))
+      return localTag
+    }
+  },
+
+  toggleMessageTag: async (messageId: string, tagId: string) => {
+    const current = get().messageTagMap[messageId] ?? []
+    const isTagged = current.includes(tagId)
+    const next = isTagged ? current.filter((id) => id !== tagId) : [...current, tagId]
+
+    set((s) => ({
+      messageTagMap: { ...s.messageTagMap, [messageId]: next },
+    }))
+
+    try {
+      if (isTagged) {
+        await api.delete(`/messages/${messageId}/tags/${tagId}`)
+      } else {
+        await api.post(`/messages/${messageId}/tags`, { tagId })
+      }
+    } catch {
+      set((s) => ({
+        messageTagMap: { ...s.messageTagMap, [messageId]: current },
+      }))
+    }
+  },
+
+  fetchTaggedMessages: async (tagId: string) => {
+    set({ loading: true })
+    try {
+      const { data } = await api.get<TaggedMessage[]>(`/tags/${tagId}/messages`)
+      set((s) => ({ taggedMessages: { ...s.taggedMessages, [tagId]: data }, loading: false }))
+    } catch {
+      set({ loading: false })
+    }
+  },
+
+  setActiveTag: (tagId) => set({ activeTagId: tagId }),
+
+  getMessageTags: (messageId: string) => {
+    const tagIds = get().messageTagMap[messageId] ?? []
+    return get().tags.filter((t) => tagIds.includes(t.id))
+  },
+}))

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -205,6 +205,22 @@ export interface StoryView {
   viewer: User
 }
 
+export interface Tag {
+  id: string
+  name: string
+  emoji: string
+  color: 'lavender' | 'sage'
+  createdAt: string
+}
+
+export interface TaggedMessage {
+  id: string
+  tagId: string
+  messageId: string
+  message: Message
+  taggedAt: string
+}
+
 export interface SearchResults {
   chats: Chat[]
   users: User[]


### PR DESCRIPTION
## Summary

- **TagSelector** bottom-sheet modal: tag list with emoji + label, multi-select with orange checkboxes, Create New Tag button with emoji picker
- **TagDetailPanel** sidebar: tag name header with emoji, tabbed content (All Messages, Media, Files, Voice, Links), tagged message list with sender avatars
- **Tag pills** on MessageBubble: Lavender/Sage pill badges showing applied tags
- **Tag action** in MessageContextMenu: Hash icon opens TagSelector
- **Tags section** in InfoPanel sidebar: clickable tag pills open TagDetailPanel
- **tagStore** (Zustand): optimistic toggle, API integration, default tags, create tag
- **Tag/TaggedMessage types** added to shared types

## Test plan

- [ ] Right-click a message > tap Tag > verify TagSelector opens
- [ ] Select/deselect tags, verify checkbox toggles and orange fill
- [ ] Create a new tag with custom emoji and name
- [ ] Verify tag pills appear below the message bubble
- [ ] Open Info Panel > Tags section > click a tag > verify TagDetailPanel opens
- [ ] Switch between tabs in TagDetailPanel